### PR TITLE
S3 fixes

### DIFF
--- a/Code/belyi_main.m
+++ b/Code/belyi_main.m
@@ -7,9 +7,9 @@ intrinsic S3Action(tau::GrpPermElt, phi::FldFunFracSchElt) -> FldFunFracSchElt
   elif tau eq S!(1,3) then
     return 1/phi;
   elif tau eq S!(2,3) then
-    return phi/(1-phi);
+    return phi/(phi-1);
   elif tau eq S!(1,2,3) then
-    return 1/phi-1;
+    return 1-1/phi;
   elif tau eq S!(1,3,2) then
     return 1/(1-phi);
   else

--- a/Code/euclidean-belyi-helper.m
+++ b/Code/euclidean-belyi-helper.m
@@ -135,10 +135,11 @@ GetN := function(presigma, delta_type);
   P := Parent(sigma[1]);
   abcIsID := (sigma[1]*sigma[2]*sigma[3] eq P!(1));
   M := Matrix(GetBasis(sigma, delta_type));
-    // N := AbsoluteValue(Determinant(M));
+  // N := AbsoluteValue(Determinant(M));
     // JV: this is overkill for many purposes, we only need to work with the lcm!
   N := Lcm(M[1,1],M[2,2]);
   return N, AbsoluteValue(Determinant(M));
+  // return N;
 end function;
 
 //===============================================================
@@ -170,6 +171,7 @@ PickKernelWithDistinctXs := function(presigma, delta_type);
   end for;
   KernelRelativeToStandardBasis := [[p[1]*n1, p[1]*n2 + p[2]*m2] : p in coors];
   _, N := GetN(presigma, delta_type);
+  // N := GetN(presigma, delta_type);
   scaledKer := [[(1/N)*p[1], (1/N)*p[2]]: p in KernelRelativeToStandardBasis];
   Exclude(~scaledKer, [0,0]);
   return scaledKer;

--- a/Code/nonhyperbolic.m
+++ b/Code/nonhyperbolic.m
@@ -399,8 +399,31 @@ intrinsic EuclideanBelyiMap(sigma::SeqEnum[GrpPermElt] : Al := "Splitting") -> F
 
   abc := [Order(sigma_s) : sigma_s in sigma];
   d := Degree(Parent(sigma[1]));
-  prec := d*100;  // wild guess
+  prec := 20*d;  // wild guess
+
+  a,b,c := Explode(abc);
+  if a gt b and b gt c then
+    tau := Sym(3)!(1,3);
+  elif a gt b and a gt c then
+    assert b le c;
+    tau := Sym(3)!(1,2,3);
+  elif a gt b then
+    assert a le c and b le c;
+    tau := Sym(3)!(1,2);
+  elif a gt c then
+    assert a le b;
+    tau := Sym(3)!(1,3,2); 
+  elif b gt c then
+    assert a le b and a le c;
+    tau := Sym(3)!(2,3);
+  else
+    assert a le b and b le c;
+    tau := Id(Sym(3));
+  end if;
+  sigma := S3Action(tau, sigma);
+  abc := [Order(sigma_s) : sigma_s in sigma];
 
   X, phi := ComputeEucBelyiMap(sigma, abc, prec : Al := Al);
+  phi := S3Action(tau^-1,phi);
   return X, phi;
 end intrinsic;


### PR DESCRIPTION
Weirdly, the function S3Action was giving two wrong maps (stupid sign errors).  I don't know how we missed these!

Hopefully I got it all right!

> sigma := 
> [ Sym(6) |
>     (1, 4)(2, 5)(3, 6),
>     (1, 3, 5)(2, 4, 6),
>     (1, 2, 3, 4, 5, 6)
> ];
> for tau in Sym(3) do
for>   BelyiMap(S3Action(tau,sigma));
for> end for;
Elliptic Curve defined by y^2 = x^3 + 1 over Rational Field
x^3 + 1
Elliptic Curve defined by y^2 = x^3 + 1 over Rational Field
x^3/(x^3 + 1)
Elliptic Curve defined by y^2 = x^3 + 1 over Rational Field
-1/x^3
Elliptic Curve defined by y^2 = x^3 + 1 over Rational Field
(x^3 + 1)/x^3
Elliptic Curve defined by y^2 = x^3 + 1 over Rational Field
-x^3
Elliptic Curve defined by y^2 = x^3 + 1 over Rational Field
1/(x^3 + 1)
