### PR TITLE
Genus one -- improvements?

### DIFF
--- a/Code/hyperelliptic.m
+++ b/Code/hyperelliptic.m
@@ -22,6 +22,17 @@ RemoveLeadingZerosLaurent := function(f,eps);
   return f;
 end function;
 
+ZeroifyCoeffsLaurent := function(f,eps);
+  f := RemoveLeadingZerosLaurent(f,eps);
+  vf := Valuation(f);
+  for i := vf to AbsolutePrecision(f)-1 do
+    if Abs(Coefficient(f,i)) lt eps then
+      f -:= Coefficient(f,i)*Parent(f).1^i;
+    end if;
+  end for;
+  return f;
+end function;
+
 function ZeroifyCoeffs(coeffs, eps)
   assert Type(coeffs) eq SeqEnum;
   //assert #coeffs gt 0;

--- a/Code/theta.m
+++ b/Code/theta.m
@@ -19,6 +19,7 @@ intrinsic TriangleTheta(Sk::SeqEnum[SeqEnum[RngSerPowElt]], Gamma::GrpPSL2Tri :
     // TODO: Use finer information from automorphism group here (PointedReps?)
     sigma := DefiningPermutation(Gamma);
     _, gap1 := Max([#c : c in CycleDecomposition(sigma[1])]);
+    gap1 := 1;   // blarg?
     Sk1 := [f[gap1] : f in Sk];
 
     // Find the element in the basis with the smallest "gap" between nonzero coefficients
@@ -411,9 +412,15 @@ intrinsic RecognizeOverK(Skc::SeqEnum[SeqEnum[FldComElt]], K::FldAlg, v::PlcNumE
   Skb := [];
   for fc in Skc do
     fb := [];
+    prevden := 1;
     for n := 0 to #fc-1 do
       if m eq 1 then
-        lin := LinearRelation(ZKbCC cat [-Re(fc[n+1])] : Al := "LLL");
+        powrel := PowerRelation(-prevden*Re(fc[n+1]),1 : Al := "LLL");
+        if Degree(powrel) lt 1 then 
+          lin := [0,1];
+        else
+          lin := Eltseq(powrel);
+        end if;
       else
         lin := LinearRelation(ZKbCC cat [-fc[n+1]] : Al := "LLL");
       end if;
@@ -421,7 +428,8 @@ intrinsic RecognizeOverK(Skc::SeqEnum[SeqEnum[FldComElt]], K::FldAlg, v::PlcNumE
         error "Failed to find linear relation in RecognizeOverK";
       end if;
       print "Denominator", lin[m+1], "should be not too large!";
-      Append(~fb, (ZK!lin[1..m])/lin[m+1]);
+      Append(~fb, (ZK!lin[1..m])/lin[m+1]/prevden);
+      prevden *:= lin[m+1];
       fbv := CC!Evaluate(fb[#fb],v : Precision := Precision(CC));
       if conj then fbv := Conjugate(fbv); end if;
       err := Abs(fbv - fc[n+1]);


### PR DESCRIPTION
Fiddling with genus one for the example below.  This has degree 28 and surprisingly, when we write phi(x,y) = numer/denom, we usually need an "extra zero" making deg(denom) > 28, but in this case it isn't necessary (we magically have deg(numer) = 27 and deg(denom) = 28).  This creates some numerical problems in computing with series and we were checking the wrong thing to see if we needed an extra zero.

```
sigma := [Sym(28) | (2, 21, 10)(3, 26, 20)(4, 8, 25)(5, 14, 7)(6, 15, 13)(9, 11, 24)(12, 16, 
        23)(17, 28, 22)(18, 19, 27),
    (1, 12, 6, 4, 11, 18, 16)(2, 22, 21, 5, 19, 9, 14)(3, 17, 10, 28, 20, 8, 
        13)(7, 24, 25, 26, 15, 23, 27),
    (1, 16)(2, 17)(3, 28)(4, 24)(5, 27)(6, 8)(7, 9)(10, 22)(11, 19)(12, 15)(13, 
        26)(14, 21)(18, 23)(20, 25)
];
Gamma := TriangleSubgroup(sigma);
SetVerbose("Shimura", true);
X, phi := BelyiMap(Gamma : prec := 100);
```