### PR TITLE
External certified relation finder for the MakeK recognition stage

### DIFF
--- a/.github/workflows/c-solver.yml
+++ b/.github/workflows/c-solver.yml
@@ -16,8 +16,10 @@ jobs:
       - name: Install FLINT
         run: sudo apt-get update && sudo apt-get install -y libflint-dev libmpfr-dev libgmp-dev
       - name: Build
-        run: make -C Cext CC=${{ matrix.cc }}
-      - name: Selftest
+        run: make -C Cext all CC=${{ matrix.cc }}
+      - name: Selftest (powser_arnoldi)
         run: ./Cext/powser_arnoldi --selftest | tee /dev/stderr | grep -q "SELFTEST PASSED"
+      - name: Selftest (makek_relfinder)
+        run: ./Cext/makek_relfinder --selftest | tee /dev/stderr | grep -q "SELFTEST PASSED"
       - name: Benchmark build
         run: make -C Cext bench CC=${{ matrix.cc }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.DS_Store
 Cext/powser_arnoldi
 Cext/powser_bench
+Cext/makek_relfinder

--- a/Cext/Makefile
+++ b/Cext/Makefile
@@ -1,5 +1,8 @@
-# External C solver for the Arnoldi stage of PowerSeriesBasis
-# (used by Al := "CArnoldi" in Code/powser_iter_arfed.m)
+# External C solvers:
+#   powser_arnoldi  -- Arnoldi stage of PowerSeriesBasis
+#                      (used by Al := "CArnoldi" in Code/powser_iter_arfed.m)
+#   makek_relfinder -- batched certified recognition for the MakeK stage
+#                      (used when MAKEK_RELFINDER_BIN is set; see Code/theta.m)
 #
 # Linux:  make            (needs libflint-dev >= 3.0, libmpfr-dev, libgmp-dev)
 # macOS:  make mac        (brew install flint mpfr gmp)
@@ -9,8 +12,13 @@ CC = gcc
 CFLAGS = -O2 -pthread
 LIBS = -lflint -lmpfr -lgmp -lm
 
+all: powser_arnoldi makek_relfinder
+
 powser_arnoldi: powser_arnoldi.c
 	$(CC) $(CFLAGS) powser_arnoldi.c -o powser_arnoldi $(LIBS)
+
+makek_relfinder: makek_relfinder.c
+	$(CC) $(CFLAGS) makek_relfinder.c -o makek_relfinder $(LIBS)
 
 mac: powser_arnoldi.c
 	clang -O2 -pthread powser_arnoldi.c -o powser_arnoldi \
@@ -30,10 +38,11 @@ server: powser_arnoldi.c
 bench: powser_bench.c
 	$(CC) $(CFLAGS) powser_bench.c -o powser_bench $(LIBS)
 
-test: powser_arnoldi
+test: powser_arnoldi makek_relfinder
 	./powser_arnoldi --selftest
+	./makek_relfinder --selftest
 
 clean:
-	rm -f powser_arnoldi powser_bench
+	rm -f powser_arnoldi powser_bench makek_relfinder
 
-.PHONY: mac test clean server
+.PHONY: all mac test clean server

--- a/Cext/Makefile
+++ b/Cext/Makefile
@@ -12,6 +12,10 @@ CC = gcc
 CFLAGS = -O2 -pthread
 LIBS = -lflint -lmpfr -lgmp -lm
 
+BREWFLAGS = -I$$(brew --prefix flint)/include -L$$(brew --prefix flint)/lib \
+	  -I$$(brew --prefix mpfr)/include -L$$(brew --prefix mpfr)/lib \
+	  -I$$(brew --prefix gmp)/include  -L$$(brew --prefix gmp)/lib
+
 all: powser_arnoldi makek_relfinder
 
 powser_arnoldi: powser_arnoldi.c
@@ -20,20 +24,19 @@ powser_arnoldi: powser_arnoldi.c
 makek_relfinder: makek_relfinder.c
 	$(CC) $(CFLAGS) makek_relfinder.c -o makek_relfinder $(LIBS)
 
-mac: powser_arnoldi.c
-	clang -O2 -pthread powser_arnoldi.c -o powser_arnoldi \
-	  -I$$(brew --prefix flint)/include -L$$(brew --prefix flint)/lib \
-	  -I$$(brew --prefix mpfr)/include -L$$(brew --prefix mpfr)/lib \
-	  -I$$(brew --prefix gmp)/include  -L$$(brew --prefix gmp)/lib \
-	  $(LIBS)
+mac: powser_arnoldi.c makek_relfinder.c
+	clang -O2 -pthread powser_arnoldi.c -o powser_arnoldi $(BREWFLAGS) $(LIBS)
+	clang -O2 -pthread makek_relfinder.c -o makek_relfinder $(BREWFLAGS) $(LIBS)
 
 # For servers without admin access: first run  sh build_deps.sh  to build
 # GMP/MPFR/FLINT into PREFIX, then this target static-links against them
 # (no LD_LIBRARY_PATH needed at runtime).
 PREFIX ?= $(HOME)/.local/powser
-server: powser_arnoldi.c
-	$(CC) $(CFLAGS) powser_arnoldi.c -o powser_arnoldi -I$(PREFIX)/include \
+STATICLIBS = -I$(PREFIX)/include \
 	  $(PREFIX)/lib/libflint.a $(PREFIX)/lib/libmpfr.a $(PREFIX)/lib/libgmp.a -lm
+server: powser_arnoldi.c makek_relfinder.c
+	$(CC) $(CFLAGS) powser_arnoldi.c -o powser_arnoldi $(STATICLIBS)
+	$(CC) $(CFLAGS) makek_relfinder.c -o makek_relfinder $(STATICLIBS)
 
 bench: powser_bench.c
 	$(CC) $(CFLAGS) powser_bench.c -o powser_bench $(LIBS)

--- a/Cext/Makefile
+++ b/Cext/Makefile
@@ -12,6 +12,11 @@ CC = gcc
 CFLAGS = -O2 -pthread
 LIBS = -lflint -lmpfr -lgmp -lm
 
+FLINT_BREW_FLAGS = \
+	-I$$(brew --prefix flint)/include -L$$(brew --prefix flint)/lib \
+	-I$$(brew --prefix mpfr)/include -L$$(brew --prefix mpfr)/lib \
+	-I$$(brew --prefix gmp)/include  -L$$(brew --prefix gmp)/lib
+
 all: powser_arnoldi makek_relfinder
 
 powser_arnoldi: powser_arnoldi.c
@@ -20,19 +25,18 @@ powser_arnoldi: powser_arnoldi.c
 makek_relfinder: makek_relfinder.c
 	$(CC) $(CFLAGS) makek_relfinder.c -o makek_relfinder $(LIBS)
 
-mac: powser_arnoldi.c
-	clang -O2 -pthread powser_arnoldi.c -o powser_arnoldi \
-	  -I$$(brew --prefix flint)/include -L$$(brew --prefix flint)/lib \
-	  -I$$(brew --prefix mpfr)/include -L$$(brew --prefix mpfr)/lib \
-	  -I$$(brew --prefix gmp)/include  -L$$(brew --prefix gmp)/lib \
-	  $(LIBS)
+mac: powser_arnoldi.c makek_relfinder.c
+	clang -O2 -pthread powser_arnoldi.c -o powser_arnoldi $(FLINT_BREW_FLAGS) $(LIBS)
+	clang -O2 -pthread makek_relfinder.c -o makek_relfinder $(FLINT_BREW_FLAGS) $(LIBS)
 
 # For servers without admin access: first run  sh build_deps.sh  to build
 # GMP/MPFR/FLINT into PREFIX, then this target static-links against them
 # (no LD_LIBRARY_PATH needed at runtime).
 PREFIX ?= $(HOME)/.local/powser
-server: powser_arnoldi.c
+server: powser_arnoldi.c makek_relfinder.c
 	$(CC) $(CFLAGS) powser_arnoldi.c -o powser_arnoldi -I$(PREFIX)/include \
+	  $(PREFIX)/lib/libflint.a $(PREFIX)/lib/libmpfr.a $(PREFIX)/lib/libgmp.a -lm
+	$(CC) $(CFLAGS) makek_relfinder.c -o makek_relfinder -I$(PREFIX)/include \
 	  $(PREFIX)/lib/libflint.a $(PREFIX)/lib/libmpfr.a $(PREFIX)/lib/libgmp.a -lm
 
 bench: powser_bench.c

--- a/Cext/makek_relfinder.c
+++ b/Cext/makek_relfinder.c
@@ -246,8 +246,20 @@ recognize_one(cand_t *c, slong maxm, slong prec)
                 double a = fabs(fmpz_get_d(fmpz_poly_get_coeff_ptr(rel, i)));
                 if (a > 1 && log10(a) > log10H) log10H = log10(a);
             }
+            /* noise floor must account for |u|: evaluating a height-H
+             * relation at u carries error ~ H * max(1,|u|)^deg * 10^-p */
+            double log10u = 0;
+            {
+                arb_t au;
+                arb_init(au);
+                acb_abs(au, c->u, 64);
+                double du = arf_get_d(arb_midref(au), ARF_RND_UP);
+                if (du > 1) log10u = log10(du);
+                arb_clear(au);
+            }
             double gap = lll_gap_bits(B, row, n, n + 2);
-            if (gap < GAP_CERT_BITS || lr > -p10 + log10H + 30)
+            if (gap < GAP_CERT_BITS
+                || lr > -p10 + log10H + fmpz_poly_degree(rel) * log10u + 30)
             {
                 fmpz_poly_clear(rel);
                 continue;   /* junk relation: precision cannot certify */
@@ -271,8 +283,17 @@ recognize_one(cand_t *c, slong maxm, slong prec)
                     double a = fabs(fmpz_get_d(fmpz_poly_get_coeff_ptr(pf, i)));
                     if (a > 1 && log10(a) > log10Hf) log10Hf = log10(a);
                 }
+                double log10u = 0;
+                {
+                    arb_t au;
+                    arb_init(au);
+                    acb_abs(au, c->u, 64);
+                    double du = arf_get_d(arb_midref(au), ARF_RND_UP);
+                    if (du > 1) log10u = log10(du);
+                    arb_clear(au);
+                }
                 double p10 = prec * 0.30102999566398119521;
-                if (lf <= -p10 + log10Hf + 40)
+                if (lf <= -p10 + log10Hf + fmpz_poly_degree(pf) * log10u + 40)
                 {
                     fmpz_poly_set(c->minpoly, pf);
                     c->log10resid = lf;
@@ -610,11 +631,29 @@ overk_seq(oseq_t *s, const acb_ptr basis, slong m, slong prec,
                  * gap (>= GAP_UNCERT_BITS) -- the marginal regime the
                  * legacy path silently accepts; tagged for the caller.
                  * No gap: junk, contributes to NOPREC.  Both tiers also
-                 * require the residual at the exact-relation noise floor. */
+                 * require the residual at the exact-relation noise floor,
+                 * which must account for the magnitudes of the basis
+                 * embeddings and the (prevden-scaled) target. */
                 double p10 = prec * 0.30102999566398119521;
+                double log10mag = 0;
+                {
+                    arb_t am;
+                    arb_init(am);
+                    for (slong i = 0; i < m; i++)
+                    {
+                        acb_abs(am, basis + i, 64);
+                        double d0 = arf_get_d(arb_midref(am), ARF_RND_UP);
+                        if (d0 > 1 && log10(d0) > log10mag) log10mag = log10(d0);
+                    }
+                    acb_abs(am, s->t + n, 64);
+                    double d1 = arf_get_d(arb_midref(am), ARF_RND_UP);
+                    d1 *= fabs(fmpz_get_d(prevden));
+                    if (d1 > 1 && log10(d1) > log10mag) log10mag = log10(d1);
+                    arb_clear(am);
+                }
                 double gap = lll_gap_bits(M, row, m + 1, m + 3);
                 int certified = (gap >= GAP_CERT_BITS);
-                if (gap >= GAP_UNCERT_BITS && lr <= -p10 + log10H + 30)
+                if (gap >= GAP_UNCERT_BITS && lr <= -p10 + log10H + log10mag + 30)
                 {
                     /* accept: coords = a, den = q * prevden (sign into a) */
                     fmpz_t den;

--- a/Cext/makek_relfinder.c
+++ b/Cext/makek_relfinder.c
@@ -57,6 +57,67 @@ typedef struct {
     double log10resid;
 } cand_t;
 
+/* log2 of the L2 norm of a matrix row (via bit length of the sum of
+ * squares); used for the LLL gap test */
+static double
+row_log2norm(const fmpz_mat_t M, slong row, slong ncols)
+{
+    fmpz_t ss, sq;
+    double out;
+    fmpz_init(ss);
+    fmpz_init(sq);
+    for (slong j = 0; j < ncols; j++)
+    {
+        fmpz_mul(sq, fmpz_mat_entry(M, row, j), fmpz_mat_entry(M, row, j));
+        fmpz_add(ss, ss, sq);
+    }
+    out = fmpz_is_zero(ss) ? -1e9 : 0.5 * (double) fmpz_bits(ss);
+    fmpz_clear(ss);
+    fmpz_clear(sq);
+    return out;
+}
+
+/* Block gap test.  A reduced relation lattice splits into a block of short
+ * rows (the true relation and, in the minpoly mode with bound > degree, its
+ * x^k multiples) and a block of junk rows at the lattice noise scale.  Sort
+ * the row norms, find the largest jump between consecutive norms, and
+ * return that jump (in bits) if the candidate row lies in the lower block
+ * -- else 0.  Junk-only bases have no significant jump. */
+static double
+lll_gap_bits(const fmpz_mat_t M, slong row, slong nrows, slong ncols)
+{
+    double *norms = malloc(nrows * sizeof(double));
+    double mine = row_log2norm(M, row, ncols);
+    slong nn = 0;
+    for (slong r = 0; r < nrows; r++)
+    {
+        double nr = row_log2norm(M, r, ncols);
+        if (nr > -1e8)
+            norms[nn++] = nr;
+    }
+    if (nn < 2) { free(norms); return 0.0; }
+    /* insertion sort (nn is tiny) */
+    for (slong i = 1; i < nn; i++)
+    {
+        double v = norms[i];
+        slong j = i - 1;
+        while (j >= 0 && norms[j] > v) { norms[j + 1] = norms[j]; j--; }
+        norms[j + 1] = v;
+    }
+    double best_jump = 0.0, blocktop = norms[0];
+    for (slong i = 0; i + 1 < nn; i++)
+    {
+        double jump = norms[i + 1] - norms[i];
+        if (jump > best_jump) { best_jump = jump; blocktop = norms[i]; }
+    }
+    double out = (mine <= blocktop + 1e-9) ? best_jump : 0.0;
+    free(norms);
+    return out;
+}
+
+#define GAP_CERT_BITS 40.0
+#define GAP_UNCERT_BITS 10.0
+
 typedef struct {
     cand_t *cands;
     slong ncand;
@@ -172,9 +233,10 @@ recognize_one(cand_t *c, slong maxm, slong prec)
         /* certify the relation before factoring.  Two conditions:
          * (a) the residual sits at the exact-relation noise floor,
          *     |rel(u)| <= 10^(-p + log10 H + slack); and
-         * (b) the height is informative at this precision,
-         *     log10 H <= p / (2*(n+2)) -- LLL junk relations balance their
-         *     height near p/(n+2) digits and always violate this. */
+         * (b) the LLL gap test: the relation row is dramatically shorter
+         *     than every other row of the reduced basis.  Junk rows have
+         *     comparable norms (gap ~ 0 bits); a forced true relation
+         *     sits far below the lattice noise. */
         {
             double p10 = prec * 0.30102999566398119521;
             double lr = poly_eval_log10(rel, c->u, prec);
@@ -184,7 +246,8 @@ recognize_one(cand_t *c, slong maxm, slong prec)
                 double a = fabs(fmpz_get_d(fmpz_poly_get_coeff_ptr(rel, i)));
                 if (a > 1 && log10(a) > log10H) log10H = log10(a);
             }
-            if (log10H > p10 / (2.0 * (n + 2)) || lr > -p10 + log10H + 30)
+            double gap = lll_gap_bits(B, row, n, n + 2);
+            if (gap < GAP_CERT_BITS || lr > -p10 + log10H + 30)
             {
                 fmpz_poly_clear(rel);
                 continue;   /* junk relation: precision cannot certify */
@@ -466,6 +529,7 @@ overk_seq(oseq_t *s, const acb_ptr basis, slong m, slong prec,
         arb_t re, im;
         arf_t mid;
         int ok = 0;
+        int cert_flag = 0;
 
         acb_init(tgt);
         arb_init(re); arb_init(im); arf_init(mid);
@@ -540,10 +604,17 @@ overk_seq(oseq_t *s, const acb_ptr basis, slong m, slong prec,
                     double a = fabs(fmpz_get_d(i < m ? fmpz_mat_entry(M, row, i) : q));
                     if (a > 1 && log10(a) > log10H) log10H = log10(a);
                 }
-                /* same two-condition certification as the minpoly mode */
+                /* three-tier verdict via the LLL gap test.  CERTIFIED: the
+                 * relation row is >= GAP_CERT_BITS shorter than every other
+                 * reduced row (a forced relation).  UNCERTIFIED: a modest
+                 * gap (>= GAP_UNCERT_BITS) -- the marginal regime the
+                 * legacy path silently accepts; tagged for the caller.
+                 * No gap: junk, contributes to NOPREC.  Both tiers also
+                 * require the residual at the exact-relation noise floor. */
                 double p10 = prec * 0.30102999566398119521;
-                if (log10H <= p10 / (2.0 * (m + 3))
-                    && lr <= -p10 + log10H + 30)
+                double gap = lll_gap_bits(M, row, m + 1, m + 3);
+                int certified = (gap >= GAP_CERT_BITS);
+                if (gap >= GAP_UNCERT_BITS && lr <= -p10 + log10H + 30)
                 {
                     /* accept: coords = a, den = q * prevden (sign into a) */
                     fmpz_t den;
@@ -565,6 +636,7 @@ overk_seq(oseq_t *s, const acb_ptr basis, slong m, slong prec,
                     fmpz_clear(qa);
                     fmpz_clear(den);
                     ok = 1;
+                    cert_flag = certified;
                 }
                 arf_clear(ub);
                 arb_clear(abs);
@@ -582,7 +654,7 @@ overk_seq(oseq_t *s, const acb_ptr basis, slong m, slong prec,
             /* chain is broken; remaining targets unprocessed */
             break;
         }
-        s->status[n] = 1;
+        s->status[n] = cert_flag ? 1 : 2;
     }
     fmpz_clear(prevden);
 }
@@ -696,10 +768,11 @@ run_overk(const char *inpath, const char *outpath)
         oseq_t *s = &seqs[sidx];
         for (slong n = 0; n < s->nt; n++)
         {
-            if (s->status[n] == 1)
+            if (s->status[n] == 1 || s->status[n] == 2)
             {
                 nfound++;
-                fprintf(fout, "FOUND %ld %ld ", sidx, n);
+                fprintf(fout, "%s %ld %ld ",
+                        s->status[n] == 1 ? "FOUND" : "UNCERT", sidx, n);
                 fmpz_fprint(fout, s->dens + n);
                 for (slong i = 0; i < m; i++)
                 {

--- a/Cext/makek_relfinder.c
+++ b/Cext/makek_relfinder.c
@@ -40,6 +40,7 @@
 #include <math.h>
 
 #include <flint/fmpz.h>
+#include <flint/fmpz_vec.h>
 #include <flint/fmpz_mat.h>
 #include <flint/fmpz_lll.h>
 #include <flint/fmpz_poly.h>
@@ -168,20 +169,22 @@ recognize_one(cand_t *c, slong maxm, slong prec)
             fmpz_poly_clear(rel);
             continue;
         }
-        /* certify the relation itself before factoring: |rel(u)| must be
-         * far below what the lattice scaling alone enforces */
+        /* certify the relation before factoring.  Two conditions:
+         * (a) the residual sits at the exact-relation noise floor,
+         *     |rel(u)| <= 10^(-p + log10 H + slack); and
+         * (b) the height is informative at this precision,
+         *     log10 H <= p / (2*(n+2)) -- LLL junk relations balance their
+         *     height near p/(n+2) digits and always violate this. */
         {
+            double p10 = prec * 0.30102999566398119521;
             double lr = poly_eval_log10(rel, c->u, prec);
-            double H = 0;
+            double log10H = 0;
             for (slong i = 0; i <= fmpz_poly_degree(rel); i++)
             {
-                double a = fmpz_get_d(fmpz_poly_get_coeff_ptr(rel, i));
-                a = fabs(a);
-                if (a > H) H = a;
+                double a = fabs(fmpz_get_d(fmpz_poly_get_coeff_ptr(rel, i)));
+                if (a > 1 && log10(a) > log10H) log10H = log10(a);
             }
-            double log10H = (H > 0) ? log10(H) : 0;
-            double budget = -(prec * 0.30102999566398119521) / 2.0 + log10H;
-            if (lr > budget)
+            if (log10H > p10 / (2.0 * (n + 2)) || lr > -p10 + log10H + 30)
             {
                 fmpz_poly_clear(rel);
                 continue;   /* junk relation: precision cannot certify */
@@ -199,8 +202,14 @@ recognize_one(cand_t *c, slong maxm, slong prec)
                 if (fmpz_poly_degree(pf) < 1)
                     continue;
                 double lf = poly_eval_log10(pf, c->u, prec);
-                double budget = -(prec * 0.30102999566398119521) / 3.0;
-                if (lf < budget)
+                double log10Hf = 0;
+                for (slong i = 0; i <= fmpz_poly_degree(pf); i++)
+                {
+                    double a = fabs(fmpz_get_d(fmpz_poly_get_coeff_ptr(pf, i)));
+                    if (a > 1 && log10(a) > log10Hf) log10Hf = log10(a);
+                }
+                double p10 = prec * 0.30102999566398119521;
+                if (lf <= -p10 + log10Hf + 40)
                 {
                     fmpz_poly_set(c->minpoly, pf);
                     c->log10resid = lf;
@@ -402,14 +411,423 @@ selftest(void)
     return fails ? 1 : 0;
 }
 
+/* ================= --overk mode =================
+ *
+ * Recognize complex numbers as elements of a KNOWN field K, given the
+ * complex embeddings of an integral basis (the RecognizeOverK stage).
+ * Sequences are processed with the same denominator chaining as the Magma
+ * implementation (prevden multiplies the target, and the found q multiplies
+ * into prevden), sequentially within a sequence; certification is per
+ * target, so insufficient precision yields a NOPREC verdict instead of a
+ * silently wrong element.
+ *
+ * Input:
+ *   line 1: prec_bits  m  nseq
+ *   next 2m lines: Re, Im of the m integral-basis embeddings (conjugated
+ *                  upstream if needed)
+ *   then per sequence: one line "nt", then 2*nt lines Re, Im of targets.
+ * Output, per sequence per target (0-based indices):
+ *   FOUND <seq> <n> <den> <a_1> ... <a_m>     (target = sum a_i b_i / den)
+ *   NOPREC <seq> <n>                          (chain stops for that seq)
+ * terminated by "RELFINDER_DONE <nfound>".
+ */
+
+typedef struct {
+    slong nt;
+    acb_ptr t;
+    int *status;        /* 1 found, -1 noprec, 0 unprocessed (after a noprec) */
+    fmpz_mat_t A;       /* nt x m coordinate rows */
+    fmpz *dens;
+} oseq_t;
+
+typedef struct {
+    oseq_t *seqs;
+    slong nseq;
+    slong m;
+    slong prec;
+    acb_ptr basis;
+    const fmpz_mat_t *B0;   /* pre-reduced basis block, m x (m+2) */
+    slong next;
+    pthread_mutex_t mtx;
+} owork_t;
+
+static void
+overk_seq(oseq_t *s, const acb_ptr basis, slong m, slong prec,
+          const fmpz_mat_t B0)
+{
+    slong scale_bits = prec - 32;
+    fmpz_t prevden;
+    fmpz_init_set_ui(prevden, 1);
+
+    for (slong n = 0; n < s->nt; n++)
+    {
+        fmpz_mat_t M;
+        acb_t tgt;
+        arb_t re, im;
+        arf_t mid;
+        int ok = 0;
+
+        acb_init(tgt);
+        arb_init(re); arb_init(im); arf_init(mid);
+        acb_set(tgt, s->t + n);
+        {
+            /* target row uses -prevden * c */
+            acb_t sc;
+            acb_init(sc);
+            acb_mul_fmpz(sc, tgt, prevden, prec);
+            acb_neg(sc, sc);
+
+            fmpz_mat_init(M, m + 1, m + 3);
+            /* basis rows: coordinates from B0 cols 0..m-1, scaled cols at the
+             * end, and a zero column inserted for the q slot */
+            for (slong i = 0; i < m; i++)
+            {
+                for (slong j = 0; j < m; j++)
+                    fmpz_set(fmpz_mat_entry(M, i, j), fmpz_mat_entry(B0, i, j));
+                fmpz_set(fmpz_mat_entry(M, i, m + 1), fmpz_mat_entry(B0, i, m));
+                fmpz_set(fmpz_mat_entry(M, i, m + 2), fmpz_mat_entry(B0, i, m + 1));
+            }
+            fmpz_one(fmpz_mat_entry(M, m, m));
+            arb_mul_2exp_si(re, acb_realref(sc), scale_bits);
+            arf_set(mid, arb_midref(re));
+            arf_get_fmpz(fmpz_mat_entry(M, m, m + 1), mid, ARF_RND_NEAR);
+            arb_mul_2exp_si(im, acb_imagref(sc), scale_bits);
+            arf_set(mid, arb_midref(im));
+            arf_get_fmpz(fmpz_mat_entry(M, m, m + 2), mid, ARF_RND_NEAR);
+            acb_clear(sc);
+        }
+        {
+            fmpz_lll_t fl;
+            fmpz_lll_context_init_default(fl);
+            fmpz_lll(M, NULL, fl);
+        }
+        /* shortest rows: need q != 0 and a certified residual */
+        for (slong row = 0; row <= m && !ok; row++)
+        {
+            const fmpz *q = fmpz_mat_entry(M, row, m);
+            if (fmpz_is_zero(q))
+                continue;
+            /* residual = | sum a_i b_i - q * prevden * c | */
+            acb_t acc, term;
+            acb_init(acc); acb_init(term);
+            acb_zero(acc);
+            for (slong i = 0; i < m; i++)
+            {
+                acb_mul_fmpz(term, basis + i, fmpz_mat_entry(M, row, i), prec);
+                acb_add(acc, acc, term, prec);
+            }
+            acb_mul_fmpz(term, s->t + n, prevden, prec);
+            acb_mul_fmpz(term, term, q, prec);
+            acb_sub(acc, acc, term, prec);
+            {
+                arb_t abs;
+                fmpz_t e;
+                double lr, log10H = 0;
+                arb_init(abs);
+                fmpz_init(e);
+                acb_abs(abs, acc, prec);
+                arf_t ub; arf_init(ub);
+                arb_get_ubound_arf(ub, abs, prec);
+                if (arf_is_zero(ub))
+                    lr = -1e9;
+                else
+                {
+                    arf_abs_bound_lt_2exp_fmpz(e, ub);
+                    lr = fmpz_get_d(e) * 0.30102999566398119521;
+                }
+                for (slong i = 0; i <= m; i++)
+                {
+                    double a = fabs(fmpz_get_d(i < m ? fmpz_mat_entry(M, row, i) : q));
+                    if (a > 1 && log10(a) > log10H) log10H = log10(a);
+                }
+                /* same two-condition certification as the minpoly mode */
+                double p10 = prec * 0.30102999566398119521;
+                if (log10H <= p10 / (2.0 * (m + 3))
+                    && lr <= -p10 + log10H + 30)
+                {
+                    /* accept: coords = a, den = q * prevden (sign into a) */
+                    fmpz_t den;
+                    fmpz_init(den);
+                    fmpz_mul(den, q, prevden);
+                    if (fmpz_sgn(den) < 0)
+                    {
+                        fmpz_neg(den, den);
+                        for (slong i = 0; i < m; i++)
+                            fmpz_neg(fmpz_mat_entry(M, row, i), fmpz_mat_entry(M, row, i));
+                    }
+                    for (slong i = 0; i < m; i++)
+                        fmpz_set(fmpz_mat_entry(s->A, n, i), fmpz_mat_entry(M, row, i));
+                    fmpz_set(s->dens + n, den);
+                    fmpz_t qa;
+                    fmpz_init(qa);
+                    fmpz_abs(qa, q);
+                    fmpz_mul(prevden, prevden, qa);
+                    fmpz_clear(qa);
+                    fmpz_clear(den);
+                    ok = 1;
+                }
+                arf_clear(ub);
+                arb_clear(abs);
+                fmpz_clear(e);
+            }
+            acb_clear(acc); acb_clear(term);
+        }
+        fmpz_mat_clear(M);
+        acb_clear(tgt);
+        arb_clear(re); arb_clear(im); arf_clear(mid);
+
+        if (!ok)
+        {
+            s->status[n] = -1;
+            /* chain is broken; remaining targets unprocessed */
+            break;
+        }
+        s->status[n] = 1;
+    }
+    fmpz_clear(prevden);
+}
+
+static void *
+oworker(void *arg)
+{
+    owork_t *w = (owork_t *) arg;
+    for (;;)
+    {
+        slong i;
+        pthread_mutex_lock(&w->mtx);
+        i = w->next++;
+        pthread_mutex_unlock(&w->mtx);
+        if (i >= w->nseq)
+            break;
+        overk_seq(&w->seqs[i], w->basis, w->m, w->prec, *w->B0);
+    }
+    return NULL;
+}
+
+static int
+run_overk(const char *inpath, const char *outpath)
+{
+    FILE *fin = fopen(inpath, "r");
+    if (!fin) { fprintf(stderr, "cannot open %s\n", inpath); return 1; }
+    slong prec, m, nseq;
+    if (fscanf(fin, "%ld %ld %ld", &prec, &m, &nseq) != 3)
+    { fprintf(stderr, "bad header\n"); fclose(fin); return 1; }
+
+    char *buf = malloc(prec + 64);
+    acb_ptr basis = _acb_vec_init(m);
+    for (slong i = 0; i < m; i++)
+        for (int part = 0; part < 2; part++)
+        {
+            if (fscanf(fin, "%s", buf) != 1)
+            { fprintf(stderr, "bad basis\n"); fclose(fin); return 1; }
+            arb_set_str(part == 0 ? acb_realref(basis + i)
+                                  : acb_imagref(basis + i), buf, prec);
+        }
+
+    oseq_t *seqs = calloc(nseq, sizeof(oseq_t));
+    for (slong sidx = 0; sidx < nseq; sidx++)
+    {
+        oseq_t *s = &seqs[sidx];
+        if (fscanf(fin, "%ld", &s->nt) != 1)
+        { fprintf(stderr, "bad seq header\n"); fclose(fin); return 1; }
+        s->t = _acb_vec_init(s->nt);
+        s->status = calloc(s->nt, sizeof(int));
+        fmpz_mat_init(s->A, s->nt, m);
+        s->dens = _fmpz_vec_init(s->nt);
+        for (slong n = 0; n < s->nt; n++)
+            for (int part = 0; part < 2; part++)
+            {
+                if (fscanf(fin, "%s", buf) != 1)
+                { fprintf(stderr, "bad target\n"); fclose(fin); return 1; }
+                arb_set_str(part == 0 ? acb_realref(s->t + n)
+                                      : acb_imagref(s->t + n), buf, prec);
+            }
+    }
+    fclose(fin);
+    free(buf);
+
+    /* pre-reduce the basis block once: m rows, [I | scaled Re | scaled Im] */
+    fmpz_mat_t B0;
+    {
+        slong scale_bits = prec - 32;
+        arb_t sc;
+        arf_t mid;
+        arb_init(sc);
+        arf_init(mid);
+        fmpz_mat_init(B0, m, m + 2);
+        for (slong i = 0; i < m; i++)
+        {
+            fmpz_one(fmpz_mat_entry(B0, i, i));
+            arb_mul_2exp_si(sc, acb_realref(basis + i), scale_bits);
+            arf_set(mid, arb_midref(sc));
+            arf_get_fmpz(fmpz_mat_entry(B0, i, m), mid, ARF_RND_NEAR);
+            arb_mul_2exp_si(sc, acb_imagref(basis + i), scale_bits);
+            arf_set(mid, arb_midref(sc));
+            arf_get_fmpz(fmpz_mat_entry(B0, i, m + 1), mid, ARF_RND_NEAR);
+        }
+        fmpz_lll_t fl;
+        fmpz_lll_context_init_default(fl);
+        fmpz_lll(B0, NULL, fl);
+        arb_clear(sc);
+        arf_clear(mid);
+    }
+
+    slong nthreads = 1;
+    {
+        const char *tenv = getenv("MAKEK_RELFINDER_THREADS");
+        if (tenv) nthreads = atol(tenv);
+        if (nthreads < 1) nthreads = 1;
+        if (nthreads > nseq) nthreads = nseq;
+    }
+    owork_t w = { seqs, nseq, m, prec, basis, (const fmpz_mat_t *) &B0, 0,
+                  PTHREAD_MUTEX_INITIALIZER };
+    pthread_t *tids = malloc(nthreads * sizeof(pthread_t));
+    for (slong t = 0; t < nthreads; t++)
+        pthread_create(&tids[t], NULL, oworker, &w);
+    for (slong t = 0; t < nthreads; t++)
+        pthread_join(tids[t], NULL);
+    free(tids);
+
+    FILE *fout = fopen(outpath, "w");
+    if (!fout) { fprintf(stderr, "cannot open %s\n", outpath); return 1; }
+    slong nfound = 0;
+    for (slong sidx = 0; sidx < nseq; sidx++)
+    {
+        oseq_t *s = &seqs[sidx];
+        for (slong n = 0; n < s->nt; n++)
+        {
+            if (s->status[n] == 1)
+            {
+                nfound++;
+                fprintf(fout, "FOUND %ld %ld ", sidx, n);
+                fmpz_fprint(fout, s->dens + n);
+                for (slong i = 0; i < m; i++)
+                {
+                    fprintf(fout, " ");
+                    fmpz_fprint(fout, fmpz_mat_entry(s->A, n, i));
+                }
+                fprintf(fout, "\n");
+            }
+            else if (s->status[n] == -1)
+                fprintf(fout, "NOPREC %ld %ld\n", sidx, n);
+            /* status 0 (after a break) intentionally unreported */
+        }
+        _acb_vec_clear(s->t, s->nt);
+        free(s->status);
+        fmpz_mat_clear(s->A);
+        _fmpz_vec_clear(s->dens, s->nt);
+    }
+    fprintf(fout, "RELFINDER_DONE %ld\n", nfound);
+    fclose(fout);
+    free(seqs);
+    fmpz_mat_clear(B0);
+    _acb_vec_clear(basis, m);
+    return 0;
+}
+
+static int
+selftest_overk(void)
+{
+    int fails = 0;
+    slong prec = 700;
+    slong m = 2;
+    acb_ptr basis = _acb_vec_init(m);
+    /* K = Q(sqrt 5), integral basis 1, (1+sqrt5)/2 */
+    arb_t s5;
+    arb_init(s5);
+    arb_sqrt_ui(s5, 5, prec);
+    acb_one(basis + 0);
+    arb_add_ui(acb_realref(basis + 1), s5, 1, prec);
+    arb_mul_2exp_si(acb_realref(basis + 1), acb_realref(basis + 1), -1);
+
+    fmpz_mat_t B0;
+    {
+        slong scale_bits = prec - 32;
+        arb_t sc; arf_t mid;
+        arb_init(sc); arf_init(mid);
+        fmpz_mat_init(B0, m, m + 2);
+        for (slong i = 0; i < m; i++)
+        {
+            fmpz_one(fmpz_mat_entry(B0, i, i));
+            arb_mul_2exp_si(sc, acb_realref(basis + i), scale_bits);
+            arf_set(mid, arb_midref(sc));
+            arf_get_fmpz(fmpz_mat_entry(B0, i, m), mid, ARF_RND_NEAR);
+            arb_mul_2exp_si(sc, acb_imagref(basis + i), scale_bits);
+            arf_set(mid, arb_midref(sc));
+            arf_get_fmpz(fmpz_mat_entry(B0, i, m + 1), mid, ARF_RND_NEAR);
+        }
+        fmpz_lll_t fl;
+        fmpz_lll_context_init_default(fl);
+        fmpz_lll(B0, NULL, fl);
+        arb_clear(sc); arf_clear(mid);
+    }
+
+    /* sequence: (3 + 7*phi)/5 then (-2 + 9*phi)/40 (chained denominators) */
+    oseq_t s;
+    s.nt = 2;
+    s.t = _acb_vec_init(2);
+    s.status = calloc(2, sizeof(int));
+    fmpz_mat_init(s.A, 2, m);
+    s.dens = _fmpz_vec_init(2);
+    acb_mul_ui(s.t + 0, basis + 1, 7, prec);
+    acb_add_ui(s.t + 0, s.t + 0, 3, prec);
+    acb_div_ui(s.t + 0, s.t + 0, 5, prec);
+    acb_mul_ui(s.t + 1, basis + 1, 9, prec);
+    acb_sub_ui(s.t + 1, s.t + 1, 2, prec);
+    acb_div_ui(s.t + 1, s.t + 1, 40, prec);
+
+    overk_seq(&s, basis, m, prec, B0);
+    if (s.status[0] != 1 || s.status[1] != 1
+        || fmpz_cmp_ui(s.dens + 0, 5) != 0
+        || fmpz_cmp_ui(fmpz_mat_entry(s.A, 0, 1), 7) != 0)
+    {
+        printf("overk selftest 1 FAILED\n");
+        fails++;
+    }
+    else
+        printf("overk selftest 1 ok: chained denominators recovered\n");
+
+    /* pi is not in K: must be NOPREC, not junk */
+    oseq_t s2;
+    s2.nt = 1;
+    s2.t = _acb_vec_init(1);
+    s2.status = calloc(1, sizeof(int));
+    fmpz_mat_init(s2.A, 1, m);
+    s2.dens = _fmpz_vec_init(1);
+    arb_const_pi(acb_realref(s2.t + 0), prec);
+    overk_seq(&s2, basis, m, prec, B0);
+    if (s2.status[0] != -1)
+    {
+        printf("overk selftest 2 FAILED: certified junk for pi\n");
+        fails++;
+    }
+    else
+        printf("overk selftest 2 ok: non-element -> NOPREC\n");
+
+    _acb_vec_clear(s.t, 2); free(s.status); fmpz_mat_clear(s.A); _fmpz_vec_clear(s.dens, 2);
+    _acb_vec_clear(s2.t, 1); free(s2.status); fmpz_mat_clear(s2.A); _fmpz_vec_clear(s2.dens, 1);
+    fmpz_mat_clear(B0);
+    arb_clear(s5);
+    _acb_vec_clear(basis, m);
+    return fails;
+}
+
 int
 main(int argc, char **argv)
 {
     if (argc == 2 && strcmp(argv[1], "--selftest") == 0)
-        return selftest();
+    {
+        int f = selftest();
+        f += selftest_overk();
+        if (f == 0)
+            printf("SELFTEST PASSED (both modes)\n");
+        return f ? 1 : 0;
+    }
+    if (argc == 4 && strcmp(argv[1], "--overk") == 0)
+        return run_overk(argv[2], argv[3]);
     if (argc != 3)
     {
-        fprintf(stderr, "usage: %s in.txt out.txt | --selftest\n", argv[0]);
+        fprintf(stderr, "usage: %s in.txt out.txt | --overk in.txt out.txt | --selftest\n", argv[0]);
         return 2;
     }
     return run_file(argv[1], argv[2]);

--- a/Cext/makek_relfinder.c
+++ b/Cext/makek_relfinder.c
@@ -1,0 +1,416 @@
+/* makek_relfinder.c -- batched, certified algebraic-number recognition for
+ * the MakeK stage of BelyiMap (FLINT >= 3.0: fmpz_lll + fmpz_poly_factor +
+ * arb/acb).
+ *
+ * The Magma-side recognition loop (genuszero.m / theta.m MakeK) walks
+ * candidate degrees m = passportsize..1 over ~50 numerical coefficients,
+ * calling PowerRelation once per (coefficient, degree) pair.  Each call is
+ * minutes of Magma-side exact LLL, the loop is O(m * #coeffs) calls, and --
+ * crucially -- when the working precision cannot certify any relation the
+ * loop grinds to the very end before failing (observed: an M24 genus-0 run
+ * spent 15+ CPU-hours in 134 doomed MakeK calls at prec 400 before being
+ * killed).
+ *
+ * This tool replaces that loop with ONE pass: for each candidate coefficient
+ * u it runs a single integer-relation LLL at the passport degree bound,
+ * factors the resulting relation over Z, and certifies which irreducible
+ * factor actually vanishes at u (arb evaluation at full precision).  The
+ * true minimal polynomial (any degree <= bound) falls out directly; if
+ * nothing certifies, the candidate is reported NOPREC, so the caller can
+ * abort with "insufficient precision" in seconds instead of days.
+ *
+ * Input (text file, decimal reals as printed by Magma):
+ *   line 1:  prec_bits  ncand  maxm
+ *   then per candidate, two lines: Re(u) and Im(u) as decimal strings.
+ * Output (text file, machine-parseable, no eval needed on the Magma side):
+ *   per candidate one line:
+ *     FOUND <index> <degree> <log10resid> <c_0> ... <c_degree>
+ *   or
+ *     NOPREC <index>
+ *   terminated by a line "RELFINDER_DONE <nfound>".
+ *
+ * Threads: MAKEK_RELFINDER_THREADS (default 1) over candidates.
+ * Selftest: ./makek_relfinder --selftest
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <math.h>
+
+#include <flint/fmpz.h>
+#include <flint/fmpz_mat.h>
+#include <flint/fmpz_lll.h>
+#include <flint/fmpz_poly.h>
+#include <flint/fmpz_poly_factor.h>
+#include <flint/arb.h>
+#include <flint/acb.h>
+#include <flint/arf.h>
+
+typedef struct {
+    slong idx;
+    acb_t u;            /* the complex number to recognize */
+    int status;         /* 0 = pending, 1 = found, -1 = noprec */
+    fmpz_poly_t minpoly;
+    double log10resid;
+} cand_t;
+
+typedef struct {
+    cand_t *cands;
+    slong ncand;
+    slong maxm;
+    slong prec;
+    slong next;         /* work queue cursor */
+    pthread_mutex_t mtx;
+} work_t;
+
+/* certified |p(u)| in arb; returns log10 of an upper bound on |p(u)|, and
+ * writes the midpoint magnitude for reporting */
+static double
+poly_eval_log10(const fmpz_poly_t p, const acb_t u, slong prec)
+{
+    acb_t val;
+    arb_t abs;
+    double out;
+    acb_init(val);
+    arb_init(abs);
+    /* Horner with fmpz coefficients */
+    acb_zero(val);
+    for (slong i = fmpz_poly_degree(p); i >= 0; i--)
+    {
+        acb_mul(val, val, u, prec);
+        acb_add_fmpz(val, val, fmpz_poly_get_coeff_ptr((fmpz_poly_struct *) p, i), prec);
+    }
+    acb_abs(abs, val, prec);
+    /* upper bound of the ball */
+    {
+        arf_t ub;
+        arf_init(ub);
+        arb_get_ubound_arf(ub, abs, prec);
+        if (arf_is_zero(ub))
+            out = -1e9;
+        else
+            out = arf_get_d(ub, ARF_RND_UP);
+        if (out > 0)
+            out = log10(out);
+        else if (out == 0)
+            out = -1e9;
+        else
+            out = -1e9; /* negative magnitude impossible */
+        /* arf_get_d saturates; recompute via mag exponent for tiny values */
+        if (!arf_is_zero(ub))
+        {
+            fmpz_t e;
+            fmpz_init(e);
+            arf_abs_bound_lt_2exp_fmpz(e, ub);
+            out = fmpz_get_d(e) * 0.30102999566398119521;
+            fmpz_clear(e);
+        }
+        arf_clear(ub);
+    }
+    arb_clear(abs);
+    acb_clear(val);
+    return out;
+}
+
+/* one candidate: LLL at degree maxm, factor, certify.  Returns 1 if found. */
+static int
+recognize_one(cand_t *c, slong maxm, slong prec)
+{
+    slong n = maxm + 1;            /* number of relation coefficients */
+    slong scale_bits = prec - 32;  /* lattice scaling */
+    fmpz_mat_t B;
+    acb_t upow;
+    arb_t re, im;
+    arf_t mid;
+    int found = 0;
+
+    if (scale_bits < 64)
+        return 0;
+
+    fmpz_mat_init(B, n, n + 2);
+    acb_init(upow);
+    arb_init(re);
+    arb_init(im);
+    arf_init(mid);
+
+    /* rows: identity block + scaled Re/Im of u^i */
+    acb_one(upow);
+    for (slong i = 0; i < n; i++)
+    {
+        fmpz_one(fmpz_mat_entry(B, i, i));
+        arb_mul_2exp_si(re, acb_realref(upow), scale_bits);
+        arb_mul_2exp_si(im, acb_imagref(upow), scale_bits);
+        arf_set(mid, arb_midref(re));
+        arf_get_fmpz(fmpz_mat_entry(B, i, n), mid, ARF_RND_NEAR);
+        arf_set(mid, arb_midref(im));
+        arf_get_fmpz(fmpz_mat_entry(B, i, n + 1), mid, ARF_RND_NEAR);
+        if (i + 1 < n)
+            acb_mul(upow, upow, c->u, prec);
+    }
+
+    {
+        fmpz_lll_t fl;
+        fmpz_lll_context_init_default(fl);
+        fmpz_lll(B, NULL, fl);
+    }
+
+    /* try the few shortest rows as relations */
+    for (slong row = 0; row < n && row < 4 && !found; row++)
+    {
+        fmpz_poly_t rel;
+        fmpz_poly_init(rel);
+        for (slong i = 0; i < n; i++)
+            fmpz_poly_set_coeff_fmpz(rel, i, fmpz_mat_entry(B, row, i));
+        if (fmpz_poly_degree(rel) < 1)
+        {
+            fmpz_poly_clear(rel);
+            continue;
+        }
+        /* certify the relation itself before factoring: |rel(u)| must be
+         * far below what the lattice scaling alone enforces */
+        {
+            double lr = poly_eval_log10(rel, c->u, prec);
+            double H = 0;
+            for (slong i = 0; i <= fmpz_poly_degree(rel); i++)
+            {
+                double a = fmpz_get_d(fmpz_poly_get_coeff_ptr(rel, i));
+                a = fabs(a);
+                if (a > H) H = a;
+            }
+            double log10H = (H > 0) ? log10(H) : 0;
+            double budget = -(prec * 0.30102999566398119521) / 2.0 + log10H;
+            if (lr > budget)
+            {
+                fmpz_poly_clear(rel);
+                continue;   /* junk relation: precision cannot certify */
+            }
+        }
+        /* factor over Z; certified minimal polynomial = the irreducible
+         * factor that vanishes at u */
+        {
+            fmpz_poly_factor_t fac;
+            fmpz_poly_factor_init(fac);
+            fmpz_poly_factor(fac, rel);
+            for (slong f = 0; f < fac->num && !found; f++)
+            {
+                fmpz_poly_struct *pf = fac->p + f;
+                if (fmpz_poly_degree(pf) < 1)
+                    continue;
+                double lf = poly_eval_log10(pf, c->u, prec);
+                double budget = -(prec * 0.30102999566398119521) / 3.0;
+                if (lf < budget)
+                {
+                    fmpz_poly_set(c->minpoly, pf);
+                    c->log10resid = lf;
+                    found = 1;
+                }
+            }
+            fmpz_poly_factor_clear(fac);
+        }
+        fmpz_poly_clear(rel);
+    }
+
+    fmpz_mat_clear(B);
+    acb_clear(upow);
+    arb_clear(re);
+    arb_clear(im);
+    arf_clear(mid);
+    return found;
+}
+
+static void *
+worker(void *arg)
+{
+    work_t *w = (work_t *) arg;
+    for (;;)
+    {
+        slong i;
+        pthread_mutex_lock(&w->mtx);
+        i = w->next++;
+        pthread_mutex_unlock(&w->mtx);
+        if (i >= w->ncand)
+            break;
+        cand_t *c = &w->cands[i];
+        c->status = recognize_one(c, w->maxm, w->prec) ? 1 : -1;
+    }
+    return NULL;
+}
+
+static int
+run_file(const char *inpath, const char *outpath)
+{
+    FILE *fin = fopen(inpath, "r");
+    if (!fin) { fprintf(stderr, "cannot open %s\n", inpath); return 1; }
+    slong prec, ncand, maxm;
+    if (fscanf(fin, "%ld %ld %ld", &prec, &ncand, &maxm) != 3)
+    { fprintf(stderr, "bad header\n"); fclose(fin); return 1; }
+
+    cand_t *cands = calloc(ncand, sizeof(cand_t));
+    char *buf = malloc(prec + 64);
+    for (slong i = 0; i < ncand; i++)
+    {
+        cands[i].idx = i;
+        acb_init(cands[i].u);
+        fmpz_poly_init(cands[i].minpoly);
+        for (int part = 0; part < 2; part++)
+        {
+            if (fscanf(fin, "%s", buf) != 1)
+            { fprintf(stderr, "bad candidate %ld\n", i); fclose(fin); return 1; }
+            arb_set_str(part == 0 ? acb_realref(cands[i].u)
+                                  : acb_imagref(cands[i].u), buf, prec);
+        }
+    }
+    fclose(fin);
+    free(buf);
+
+    slong nthreads = 1;
+    {
+        const char *tenv = getenv("MAKEK_RELFINDER_THREADS");
+        if (tenv) nthreads = atol(tenv);
+        if (nthreads < 1) nthreads = 1;
+        if (nthreads > ncand) nthreads = ncand;
+    }
+
+    work_t w = { cands, ncand, maxm, prec, 0, PTHREAD_MUTEX_INITIALIZER };
+    pthread_t *tids = malloc(nthreads * sizeof(pthread_t));
+    for (slong t = 0; t < nthreads; t++)
+        pthread_create(&tids[t], NULL, worker, &w);
+    for (slong t = 0; t < nthreads; t++)
+        pthread_join(tids[t], NULL);
+    free(tids);
+
+    FILE *fout = fopen(outpath, "w");
+    if (!fout) { fprintf(stderr, "cannot open %s\n", outpath); return 1; }
+    slong nfound = 0;
+    for (slong i = 0; i < ncand; i++)
+    {
+        if (cands[i].status == 1)
+        {
+            nfound++;
+            fprintf(fout, "FOUND %ld %ld %.2f", i,
+                    fmpz_poly_degree(cands[i].minpoly), cands[i].log10resid);
+            for (slong k = 0; k <= fmpz_poly_degree(cands[i].minpoly); k++)
+            {
+                fprintf(fout, " ");
+                fmpz_fprint(fout, fmpz_poly_get_coeff_ptr(cands[i].minpoly, k));
+            }
+            fprintf(fout, "\n");
+        }
+        else
+            fprintf(fout, "NOPREC %ld\n", i);
+        acb_clear(cands[i].u);
+        fmpz_poly_clear(cands[i].minpoly);
+    }
+    fprintf(fout, "RELFINDER_DONE %ld\n", nfound);
+    fclose(fout);
+    free(cands);
+    return 0;
+}
+
+/* ---------- selftest ---------- */
+
+static int
+selftest(void)
+{
+    int fails = 0;
+    slong prec = 1400;   /* ~420 digits */
+
+    /* 1: u = 2^(1/3) + 5^(1/2), true minpoly degree 6, bound 12 */
+    {
+        cand_t c;
+        c.idx = 0;
+        acb_init(c.u);
+        fmpz_poly_init(c.minpoly);
+        arb_t t;
+        arb_init(t);
+        arb_set_ui(t, 2);
+        arb_root_ui(t, t, 3, prec);
+        arb_set(acb_realref(c.u), t);
+        arb_sqrt_ui(t, 5, prec);
+        arb_add(acb_realref(c.u), acb_realref(c.u), t, prec);
+        arb_zero(acb_imagref(c.u));
+        if (!recognize_one(&c, 12, prec) || fmpz_poly_degree(c.minpoly) != 6)
+        {
+            printf("selftest 1 FAILED (deg %ld)\n",
+                   c.status == 1 ? fmpz_poly_degree(c.minpoly) : -1);
+            fails++;
+        }
+        else
+            printf("selftest 1 ok: deg 6 minpoly at bound 12, log10resid %.1f\n",
+                   c.log10resid);
+        arb_clear(t);
+        acb_clear(c.u);
+        fmpz_poly_clear(c.minpoly);
+    }
+
+    /* 2: complex u = (1 + i*sqrt(7))/2, degree 2, bound 12 */
+    {
+        cand_t c;
+        acb_init(c.u);
+        fmpz_poly_init(c.minpoly);
+        arb_t t;
+        arb_init(t);
+        arb_set_d(acb_realref(c.u), 0.5);
+        arb_sqrt_ui(t, 7, prec);
+        arb_mul_2exp_si(t, t, -1);
+        arb_set(acb_imagref(c.u), t);
+        if (!recognize_one(&c, 12, prec) || fmpz_poly_degree(c.minpoly) != 2)
+        {
+            printf("selftest 2 FAILED\n");
+            fails++;
+        }
+        else
+            printf("selftest 2 ok: deg 2 complex minpoly at bound 12\n");
+        arb_clear(t);
+        acb_clear(c.u);
+        fmpz_poly_clear(c.minpoly);
+    }
+
+    /* 3: starved precision must report NOPREC, not junk: a degree-8 number
+     * with ~40-digit coefficients at 100 bits */
+    {
+        cand_t c;
+        acb_init(c.u);
+        fmpz_poly_init(c.minpoly);
+        slong lowprec = 100;
+        arb_t t;
+        arb_init(t);
+        /* u = (10^5 + 3)^(1/8) * 2^(1/3): minpoly x^24-ish heights too big */
+        arb_set_ui(t, 100003);
+        arb_root_ui(t, t, 8, lowprec);
+        arb_set(acb_realref(c.u), t);
+        arb_set_ui(t, 2);
+        arb_root_ui(t, t, 3, lowprec);
+        arb_mul(acb_realref(c.u), acb_realref(c.u), t, lowprec);
+        arb_zero(acb_imagref(c.u));
+        if (recognize_one(&c, 24, lowprec))
+        {
+            printf("selftest 3 FAILED: certified junk at starved precision\n");
+            fails++;
+        }
+        else
+            printf("selftest 3 ok: starved precision -> NOPREC\n");
+        arb_clear(t);
+        acb_clear(c.u);
+        fmpz_poly_clear(c.minpoly);
+    }
+
+    if (fails == 0)
+        printf("SELFTEST PASSED\n");
+    return fails ? 1 : 0;
+}
+
+int
+main(int argc, char **argv)
+{
+    if (argc == 2 && strcmp(argv[1], "--selftest") == 0)
+        return selftest();
+    if (argc != 3)
+    {
+        fprintf(stderr, "usage: %s in.txt out.txt | --selftest\n", argv[0]);
+        return 2;
+    }
+    return run_file(argv[1], argv[2]);
+}

--- a/Code/belyi_main.m
+++ b/Code/belyi_main.m
@@ -24,7 +24,16 @@ end intrinsic;
 
 // sigma one at a time
 intrinsic BelyiMap(sigma::SeqEnum[GrpPermElt] : prec := 0, Al := "Default", ExactAl := "AlgebraicNumbers", DegreeBound := 0, precNewton := 0, Federalize := true, PowserAl := "Arnoldi") -> Any, Any
-  {Computes the Belyi curve X and Belyi map f associated to the permutation triple sigma. Same description as below.}
+  {Computes the Belyi curve X and Belyi map f associated to the permutation triple sigma. Same description as below.
+   ExactAl := "Certified" uses the external certified relation finder for the
+   recognition stages (see Cext/makek_relfinder.c); it requires the
+   MAKEK_RELFINDER_BIN environment variable to point at the built binary.}
+
+  if ExactAl eq "Certified" then
+    require GetEnv("MAKEK_RELFINDER_BIN") ne "" :
+      "ExactAl := \"Certified\" requires the MAKEK_RELFINDER_BIN environment variable (build Cext/makek_relfinder and export its path)";
+    ExactAl := "AlgebraicNumbers";  // certified paths engage via the env var
+  end if;
 
   chi := &+[1/Order(sigma_s) : sigma_s in sigma];
   if chi ge 1 then

--- a/Code/belyi_main.m
+++ b/Code/belyi_main.m
@@ -22,6 +22,18 @@ intrinsic S3Orbit(phi::FldFunFracSchElt) -> SeqEnum
   return [S3Action(el, phi) : el in Sym(3)];
 end intrinsic;
 
+// ExactAl := "Certified" remaps to AlgebraicNumbers after checking that the
+// external relation finder is configured; the MakeK / RecognizeOverK paths
+// themselves engage via MAKEK_RELFINDER_BIN.
+RequireCertifiedExactAl := function(ExactAl);
+  if ExactAl eq "Certified" then
+    error if GetEnv("MAKEK_RELFINDER_BIN") eq "",
+      "ExactAl := \"Certified\" requires the MAKEK_RELFINDER_BIN environment variable (build Cext/makek_relfinder and export its path)";
+    return "AlgebraicNumbers";
+  end if;
+  return ExactAl;
+end function;
+
 // sigma one at a time
 intrinsic BelyiMap(sigma::SeqEnum[GrpPermElt] : prec := 0, Al := "Default", ExactAl := "AlgebraicNumbers", DegreeBound := 0, precNewton := 0, Federalize := true, PowserAl := "Arnoldi") -> Any, Any
   {Computes the Belyi curve X and Belyi map f associated to the permutation triple sigma. Same description as below.
@@ -29,11 +41,7 @@ intrinsic BelyiMap(sigma::SeqEnum[GrpPermElt] : prec := 0, Al := "Default", Exac
    recognition stages (see Cext/makek_relfinder.c); it requires the
    MAKEK_RELFINDER_BIN environment variable to point at the built binary.}
 
-  if ExactAl eq "Certified" then
-    require GetEnv("MAKEK_RELFINDER_BIN") ne "" :
-      "ExactAl := \"Certified\" requires the MAKEK_RELFINDER_BIN environment variable (build Cext/makek_relfinder and export its path)";
-    ExactAl := "AlgebraicNumbers";  // certified paths engage via the env var
-  end if;
+  ExactAl := RequireCertifiedExactAl(ExactAl);
 
   chi := &+[1/Order(sigma_s) : sigma_s in sigma];
   if chi ge 1 then
@@ -76,8 +84,11 @@ intrinsic BelyiMap(Gamma::GrpPSL2Tri : prec := 0, Al := "Default", ExactAl := "A
         NumAl := "NumericalKernel", which computes the numerical kernel using multiplied power series expansions,
         NumAl := "Newton", not implemented yet.
         ExactAl := "GaloisOrbits", which recognizes coefficients (using the entire Galois orbit) over the rationals,
-        ExactAl := "AlgebraicNumbers", which uses MakeK to recognize coefficients over a number field.
+        ExactAl := "AlgebraicNumbers", which uses MakeK to recognize coefficients over a number field,
+        ExactAl := "Certified", which uses the external certified relation finder (requires MAKEK_RELFINDER_BIN).
   }
+
+  ExactAl := RequireCertifiedExactAl(ExactAl);
 
   d := IndexDegree(Gamma);
 
@@ -256,8 +267,11 @@ intrinsic BelyiMap(Gammas::SeqEnum[GrpPSL2Tri] : prec := 0, Al := "Default", Exa
         NumAl := "NumericalKernel", which computes the numerical kernel using multiplied power series expansions,
         NumAl := "Newton", not implemented yet.
         ExactAl := "GaloisOrbits", which recognizes coefficients (using the entire Galois orbit) over the rationals,
-        ExactAl := "AlgebraicNumbers", which uses MakeK to recognize coefficients over a number field.
+        ExactAl := "AlgebraicNumbers", which uses MakeK to recognize coefficients over a number field,
+        ExactAl := "Certified", which uses the external certified relation finder (requires MAKEK_RELFINDER_BIN).
   }
+
+  ExactAl := RequireCertifiedExactAl(ExactAl);
 
   d := IndexDegree(Gammas[1]);
   if DegreeBound eq 0 then

--- a/Code/belyi_main.m
+++ b/Code/belyi_main.m
@@ -225,7 +225,8 @@ end intrinsic;
 
 // sigmas (passport at a time)
 intrinsic BelyiMap(sigmas::SeqEnum[SeqEnum[GrpPermElt]] : prec := 0, Al := "Default", ExactAl := "GaloisOrbits", DegreeBound := 0, precNewton := 0, Federalize := true, PowserAl := "Arnoldi") -> Any, Any
-  {Computes the Belyi curve X and Belyi map f associated to the permutation triple sigma. Same description as below.}
+  {Computes the Belyi curve X and Belyi map f associated to the permutation triple sigma. Same description as below.
+   ExactAl (including "Certified") is forwarded to the Gammas overload, which validates it.}
   // assertions
   chi_list := [];
   for sigma in sigmas do

--- a/Code/genuszero.m
+++ b/Code/genuszero.m
@@ -295,18 +295,29 @@ intrinsic TrianglePhiGenusZeroNumericalBelyiMap(Sk::SeqEnum[SeqEnum[RngSerPowElt
     m := #PassportRepresentatives(sigma : Pointed := true);
   end if;
 
-  vprint Shimura : "Looking for coefficient to recognize number field...";  
+  vprint Shimura : "Looking for coefficient to recognize number field...";
   bl := false;
   cfs := Reverse([u] cat phixden_seq cat phixnum_seq);
-  for mtry := m to 1 by -1 do 
-    vprintf Shimura : "    ==> trying degree m = %o", mtry;
-    cfs_ind := 0;
-    while not bl and cfs_ind lt #cfs do
-      cfs_ind +:= 1;
-      bl, K, v, conj, uCC := MakeK(cfs[cfs_ind], mtry);
-    end while;
-    if bl then break; end if;
-  end for;
+  if GetEnv("MAKEK_RELFINDER_BIN") ne "" then
+    // batched certified recognition (Cext/makek_relfinder): one threaded
+    // pass over all coefficients finds the true minimal polynomial of any
+    // degree <= m, or certifies that the precision is insufficient --
+    // instead of O(m * #cfs) sequential PowerRelation calls.
+    bl, K, v, conj, uCC := MakeKBatch(cfs, m);
+    if not bl then
+      error "MakeKBatch: no coefficient relation certifies at this precision; raise prec (or unset MAKEK_RELFINDER_BIN to use the legacy search)";
+    end if;
+  else
+    for mtry := m to 1 by -1 do
+      vprintf Shimura : "    ==> trying degree m = %o", mtry;
+      cfs_ind := 0;
+      while not bl and cfs_ind lt #cfs do
+        cfs_ind +:= 1;
+        bl, K, v, conj, uCC := MakeK(cfs[cfs_ind], mtry);
+      end while;
+      if bl then break; end if;
+    end for;
+  end if;
   if not bl then
     error "K not found; is the Galois orbit smaller than the passport size?  Try smaller m!";
   end if;

--- a/Code/genuszero.m
+++ b/Code/genuszero.m
@@ -298,6 +298,18 @@ intrinsic TrianglePhiGenusZeroNumericalBelyiMap(Sk::SeqEnum[SeqEnum[RngSerPowElt
   vprint Shimura : "Looking for coefficient to recognize number field...";
   bl := false;
   cfs := Reverse([u] cat phixden_seq cat phixnum_seq);
+  // debugging hook: dump the exact recognition inputs (full precision,
+  // magma-readable) and continue -- lets recognition be iterated offline
+  // without redoing the solver and Newton stages
+  dumpf := GetEnv("BELYI_DUMP_CFS");
+  if dumpf ne "" then
+    DF := Open(dumpf, "w");
+    Puts(DF, Sprintf("u := %m;", u));
+    Puts(DF, Sprintf("phixnum_seq := %m;", phixnum_seq));
+    Puts(DF, Sprintf("phixden_seq := %m;", phixden_seq));
+    delete DF;
+    vprintf Shimura : "  ...dumped recognition inputs to %o\n", dumpf;
+  end if;
   if GetEnv("MAKEK_RELFINDER_BIN") ne "" then
     // batched certified recognition (Cext/makek_relfinder): one threaded
     // pass over all coefficients finds the true minimal polynomial of any

--- a/Code/theta.m
+++ b/Code/theta.m
@@ -555,6 +555,46 @@ intrinsic RecognizeOverK(Skc::SeqEnum[SeqEnum[FldComElt]], K::FldAlg, v::PlcNumE
   return Skb;
 end intrinsic;
 
+function OverKRunRelfinder(seqs, ZKbCC, m, precbits, cbin, tmpdir)
+  // one --overk invocation on the given sequences; returns the found map
+  tag := Sprintf("%o_%o_%o", Getpid(), Round(1000*Realtime()) mod 10^9, Random(10^15));
+  infile := Sprintf("%o/overk_in_%o.txt", tmpdir, tag);
+  outfile := Sprintf("%o/overk_out_%o.txt", tmpdir, tag);
+  F := Open(infile, "w");
+  Puts(F, Sprintf("%o %o %o", precbits, m, #seqs));
+  for b in ZKbCC do
+    Puts(F, Sprintf("%o", Real(b)));
+    Puts(F, Sprintf("%o", Imaginary(b)));
+  end for;
+  for fc in seqs do
+    Puts(F, Sprintf("%o", #fc));
+    for c in fc do
+      Puts(F, Sprintf("%o", Real(c)));
+      Puts(F, Sprintf("%o", Imaginary(c)));
+    end for;
+  end for;
+  delete F;
+  ret := System(Sprintf("%o --overk %o %o", cbin, infile, outfile));
+  error if ret ne 0, "external relation finder (--overk) failed";
+  found := AssociativeArray();
+  done := false;
+  for line in Split(Read(outfile), "\n") do
+    parts := Split(line, " ");
+    if parts[1] eq "RELFINDER_DONE" then
+      done := true;
+    elif parts[1] eq "FOUND" or parts[1] eq "UNCERT" then
+      if parts[1] eq "UNCERT" then
+        vprintf Shimura : "  ...RecognizeOverK: coefficient %o/%o accepted UNCERTIFIED (marginal height for this precision)\n", parts[2], parts[3];
+      end if;
+      found[<StringToInteger(parts[2]) + 1, StringToInteger(parts[3]) + 1>] :=
+        <StringToInteger(parts[4]), [StringToInteger(parts[k]) : k in [5..4+m]]>;
+    end if;
+  end for;
+  error if not done, "external relation finder (--overk) output truncated";
+  System(Sprintf("rm -f %o %o", infile, outfile));
+  return found;
+end function;
+
 intrinsic RecognizeOverKBatch(Skc::SeqEnum, K::FldAlg, ZKbCC::SeqEnum : escapeOK := false) -> SeqEnum
   {Batched certified RecognizeOverK backed by the external C relation finder
    (Cext/makek_relfinder --overk).  Same semantics as the legacy loop --
@@ -575,52 +615,67 @@ intrinsic RecognizeOverKBatch(Skc::SeqEnum, K::FldAlg, ZKbCC::SeqEnum : escapeOK
   if tmpdir eq "" then
     tmpdir := "/tmp";
   end if;
-  tag := Sprintf("%o_%o_%o", Getpid(), Round(1000*Realtime()) mod 10^9, Random(10^15));
-  infile := Sprintf("%o/overk_in_%o.txt", tmpdir, tag);
-  outfile := Sprintf("%o/overk_out_%o.txt", tmpdir, tag);
+  found := OverKRunRelfinder(Skc, ZKbCC, m, precbits, cbin, tmpdir);
 
-  F := Open(infile, "w");
-  Puts(F, Sprintf("%o %o %o", precbits, m, #Skc));
-  for b in ZKbCC do
-    Puts(F, Sprintf("%o", Real(b)));
-    Puts(F, Sprintf("%o", Imaginary(b)));
-  end for;
-  for fc in Skc do
-    Puts(F, Sprintf("%o", #fc));
-    for c in fc do
-      Puts(F, Sprintf("%o", Real(c)));
-      Puts(F, Sprintf("%o", Imaginary(c)));
+  // Smooth-denominator rescale retry (the 17T7 trick, cf. Sam's
+  // denom_recognition branch): denominators grow as powers of a smooth base
+  // D along the coefficient sequences, and a sequence whose FIRST targets
+  // already carry a high power cannot start its prevden chain.  Extract D
+  // from every denominator recognized so far, probe D^j against the first
+  // failed target of each truncated sequence (one threaded call over the
+  // whole grid), and rerun the remainder of the sequence under the winning
+  // scale.  Recognized scaled targets satisfy scale*c = a/den, so
+  // c = a/(den*scale).
+  scaleof := AssociativeArray();
+  JMAX := 200;
+  for sidx in [1..#Skc] do
+    fc := Skc[sidx];
+    k0 := 1;
+    while k0 le #fc and IsDefined(found, <sidx, k0>) do k0 +:= 1; end while;
+    if k0 gt #fc then continue; end if;
+    dens := [ found[t][1] : t in Keys(found) ];
+    if #dens eq 0 then continue; end if;
+    // candidate bases: the collective smooth radical, plus the largest few
+    // individual recognized denominators (a stuck sequence's scaling is
+    // typically a power of ONE structured denominator, e.g. den(u), not of
+    // the radical of everything)
+    fac := TrialDivision(LCM(dens), 10^6);
+    Drad := &*[ Integers() | f[1] : f in fac ];
+    bigdens := Reverse(Sort(SetToSequence({ d : d in dens | d gt 1 })));
+    cands := [ Integers() | ];
+    for d in bigdens[1..Min(3, #bigdens)] cat [Drad] do
+      if d gt 1 and d notin cands then Append(~cands, d); end if;
+    end for;
+    if #cands eq 0 then continue; end if;
+    // one threaded probe over the whole (base, power) grid
+    grid := [ Parent(<1,1>) | ];
+    for ci in [1..#cands] do
+      maxj := Min(JMAX, (Precision(CC) div 3) div Max(1, #IntegerToString(cands[ci])));
+      for j in [1..maxj] do Append(~grid, <ci, j>); end for;
+    end for;
+    if #grid eq 0 then continue; end if;
+    vprintf Shimura : "  ...RecognizeOverK: sequence %o stuck at %o; probing %o candidate scales from %o bases\n", sidx, k0, #grid, #cands;
+    probe := OverKRunRelfinder([ [ CC!(cands[g[1]]^g[2]) * fc[k0] ] : g in grid ],
+                               ZKbCC, m, precbits, cbin, tmpdir);
+    scale := 0;
+    best := 0;
+    for gi in [1..#grid] do
+      if IsDefined(probe, <gi, 1>) then
+        s := cands[grid[gi][1]]^grid[gi][2];
+        if scale eq 0 or s lt scale then scale := s; best := gi; end if;
+      end if;
+    end for;
+    if scale eq 0 then continue; end if;
+    vprintf Shimura : "  ...RecognizeOverK: scale %o^%o unlocks sequence %o; rerunning remainder\n", cands[grid[best][1]], grid[best][2], sidx;
+    rerun := OverKRunRelfinder([ [ CC!scale * c : c in fc[k0..#fc] ] ],
+                               ZKbCC, m, precbits, cbin, tmpdir);
+    for n in [k0..#fc] do
+      if IsDefined(rerun, <1, n - k0 + 1>) then
+        found[<sidx, n>] := rerun[<1, n - k0 + 1>];
+        scaleof[<sidx, n>] := scale;
+      end if;
     end for;
   end for;
-  delete F;
-
-  ret := System(Sprintf("%o --overk %o %o", cbin, infile, outfile));
-  require ret eq 0 : "external relation finder (--overk) failed";
-
-  found := AssociativeArray();
-  done := false;
-  for line in Split(Read(outfile), "\n") do
-    parts := Split(line, " ");
-    if parts[1] eq "RELFINDER_DONE" then
-      done := true;
-    elif parts[1] eq "FOUND" or parts[1] eq "UNCERT" then
-      // UNCERT: the relation passes the noise-floor residual check but its
-      // height is in the marginal regime where a true relation cannot be
-      // distinguished from LLL junk at this precision.  This is exactly
-      // what the legacy path silently accepts, so accept it too -- the eps
-      // check below and the downstream BelyiMapSanityCheck arbitrate.
-      if parts[1] eq "UNCERT" then
-        vprintf Shimura : "  ...RecognizeOverK: coefficient %o/%o accepted UNCERTIFIED (marginal height for this precision)\n", parts[2], parts[3];
-      end if;
-      sidx := StringToInteger(parts[2]) + 1;
-      n := StringToInteger(parts[3]) + 1;
-      den := StringToInteger(parts[4]);
-      coords := [StringToInteger(parts[k]) : k in [5..4+m]];
-      found[<sidx, n>] := <den, coords>;
-    end if;
-  end for;
-  require done : "external relation finder (--overk) output truncated";
-  System(Sprintf("rm -f %o %o", infile, outfile));
 
   Skb := [];
   for sidx in [1..#Skc] do
@@ -632,10 +687,12 @@ intrinsic RecognizeOverKBatch(Skc::SeqEnum, K::FldAlg, ZKbCC::SeqEnum : escapeOK
         error "Insufficient precision in RecognizeOverK (certified by the external relation finder); increase prec";
       end if;
       den, coords := Explode(found[<sidx, n>]);
-      elt := K!((ZK!coords)/den);
+      scdef, sc := IsDefined(scaleof, <sidx, n>);
+      if not scdef then sc := 1; end if;
+      elt := K!((ZK!coords)/(den*sc));
       // final eps check against the numerical value, via the embedded basis
       // (ZKbCC already encodes the place and conjugation)
-      fbv := &+[ CC!coords[i]*ZKbCC[i] : i in [1..m] ] / CC!den;
+      fbv := &+[ CC!coords[i]*ZKbCC[i] : i in [1..m] ] / (CC!den * CC!sc);
       err := Abs(fbv - fc[n]);
       vprintf Shimura : "Coefficient %o of %o in array %o recognized (batch), error = %o \n",
         n, #fc, sidx, RealField(4)!err;

--- a/Code/theta.m
+++ b/Code/theta.m
@@ -265,6 +265,7 @@ intrinsic MakeKBatch(cfs::SeqEnum, m::RngIntElt) -> Any, Any, Any, Any, Any
   done := false;
   for line in Split(Read(outfile), "\n") do
     parts := Split(line, " ");
+    if #parts eq 0 then continue; end if;
     if parts[1] eq "RELFINDER_DONE" then
       done := true;
     elif parts[1] eq "NOPREC" then
@@ -580,6 +581,7 @@ function OverKRunRelfinder(seqs, ZKbCC, m, precbits, cbin, tmpdir)
   done := false;
   for line in Split(Read(outfile), "\n") do
     parts := Split(line, " ");
+    if #parts eq 0 then continue; end if;
     if parts[1] eq "RELFINDER_DONE" then
       done := true;
     elif parts[1] eq "FOUND" or parts[1] eq "UNCERT" then

--- a/Code/theta.m
+++ b/Code/theta.m
@@ -590,7 +590,15 @@ intrinsic RecognizeOverKBatch(Skc::SeqEnum, K::FldAlg, ZKbCC::SeqEnum : escapeOK
     parts := Split(line, " ");
     if parts[1] eq "RELFINDER_DONE" then
       done := true;
-    elif parts[1] eq "FOUND" then
+    elif parts[1] eq "FOUND" or parts[1] eq "UNCERT" then
+      // UNCERT: the relation passes the noise-floor residual check but its
+      // height is in the marginal regime where a true relation cannot be
+      // distinguished from LLL junk at this precision.  This is exactly
+      // what the legacy path silently accepts, so accept it too -- the eps
+      // check below and the downstream BelyiMapSanityCheck arbitrate.
+      if parts[1] eq "UNCERT" then
+        vprintf Shimura : "  ...RecognizeOverK: coefficient %o/%o accepted UNCERTIFIED (marginal height for this precision)\n", parts[2], parts[3];
+      end if;
       sidx := StringToInteger(parts[2]) + 1;
       n := StringToInteger(parts[3]) + 1;
       den := StringToInteger(parts[4]);

--- a/Code/theta.m
+++ b/Code/theta.m
@@ -501,6 +501,10 @@ intrinsic RecognizeOverK(Skc::SeqEnum[SeqEnum[FldComElt]], K::FldAlg, v::PlcNumE
 
   m := Degree(K);
 
+  if GetEnv("MAKEK_RELFINDER_BIN") ne "" and m gt 1 then
+    return RecognizeOverKBatch(Skc, K, ZKbCC : escapeOK := escapeOK);
+  end if;
+
   Skb := [];
   for fc in Skc do
     fb := [];
@@ -535,6 +539,93 @@ intrinsic RecognizeOverK(Skc::SeqEnum[SeqEnum[FldComElt]], K::FldAlg, v::PlcNumE
     Append(~Skb, fb);
   end for;
 
+  return Skb;
+end intrinsic;
+
+intrinsic RecognizeOverKBatch(Skc::SeqEnum, K::FldAlg, ZKbCC::SeqEnum : escapeOK := false) -> SeqEnum
+  {Batched certified RecognizeOverK backed by the external C relation finder
+   (Cext/makek_relfinder --overk).  Same semantics as the legacy loop --
+   integral-basis coordinates, per-sequence denominator chaining, eps check
+   -- but one threaded external pass over all sequences, and a certified
+   NOPREC verdict on insufficient precision instead of hours of grinding
+   before the same failure.}
+
+  cbin := GetEnv("MAKEK_RELFINDER_BIN");
+  require cbin ne "" : "MAKEK_RELFINDER_BIN is not set";
+  CC := Parent(ZKbCC[1]);
+  eps := 10^(-Precision(CC)/2);
+  m := Degree(K);
+  ZK := Integers(K);
+  precbits := Ceiling(Precision(CC)*3.3219280948873623);
+
+  tmpdir := GetEnv("TMPDIR");
+  if tmpdir eq "" then
+    tmpdir := "/tmp";
+  end if;
+  tag := Sprintf("%o_%o_%o", Getpid(), Round(1000*Realtime()) mod 10^9, Random(10^15));
+  infile := Sprintf("%o/overk_in_%o.txt", tmpdir, tag);
+  outfile := Sprintf("%o/overk_out_%o.txt", tmpdir, tag);
+
+  F := Open(infile, "w");
+  Puts(F, Sprintf("%o %o %o", precbits, m, #Skc));
+  for b in ZKbCC do
+    Puts(F, Sprintf("%o", Real(b)));
+    Puts(F, Sprintf("%o", Imaginary(b)));
+  end for;
+  for fc in Skc do
+    Puts(F, Sprintf("%o", #fc));
+    for c in fc do
+      Puts(F, Sprintf("%o", Real(c)));
+      Puts(F, Sprintf("%o", Imaginary(c)));
+    end for;
+  end for;
+  delete F;
+
+  ret := System(Sprintf("%o --overk %o %o", cbin, infile, outfile));
+  require ret eq 0 : "external relation finder (--overk) failed";
+
+  found := AssociativeArray();
+  done := false;
+  for line in Split(Read(outfile), "\n") do
+    parts := Split(line, " ");
+    if parts[1] eq "RELFINDER_DONE" then
+      done := true;
+    elif parts[1] eq "FOUND" then
+      sidx := StringToInteger(parts[2]) + 1;
+      n := StringToInteger(parts[3]) + 1;
+      den := StringToInteger(parts[4]);
+      coords := [StringToInteger(parts[k]) : k in [5..4+m]];
+      found[<sidx, n>] := <den, coords>;
+    end if;
+  end for;
+  require done : "external relation finder (--overk) output truncated";
+  System(Sprintf("rm -f %o %o", infile, outfile));
+
+  Skb := [];
+  for sidx in [1..#Skc] do
+    fc := Skc[sidx];
+    fb := [];
+    for n in [1..#fc] do
+      if not IsDefined(found, <sidx, n>) then
+        if escapeOK then break; end if;
+        error "Insufficient precision in RecognizeOverK (certified by the external relation finder); increase prec";
+      end if;
+      den, coords := Explode(found[<sidx, n>]);
+      elt := K!((ZK!coords)/den);
+      // final eps check against the numerical value, via the embedded basis
+      // (ZKbCC already encodes the place and conjugation)
+      fbv := &+[ CC!coords[i]*ZKbCC[i] : i in [1..m] ] / CC!den;
+      err := Abs(fbv - fc[n]);
+      vprintf Shimura : "Coefficient %o of %o in array %o recognized (batch), error = %o \n",
+        n, #fc, sidx, RealField(4)!err;
+      if err gt eps then
+        if escapeOK then break; end if;
+        error "RecognizeOverK batch result fails the eps check; increase prec";
+      end if;
+      Append(~fb, elt);
+    end for;
+    Append(~Skb, fb);
+  end for;
   return Skb;
 end intrinsic;
 

--- a/Code/theta.m
+++ b/Code/theta.m
@@ -141,27 +141,17 @@ intrinsic TriangleMakeNumberField(uCC::FldComElt, deg::RngIntElt : K := "") -> A
 end intrinsic;
 */
 
-intrinsic MakeK(uCC::Any, m::Any) -> Any, Any, Any, Any, Any
-  {MakeK!  What more to say?}
-
-  if m eq 1 then
-    vprint Shimura : "  ...m eq 1, so taking QQ";
-    K := RationalsAsNumberField();
-    v := RealPlaces(K)[1];
-    return true, K, v, false, Parent(uCC)!1;
-  end if;
-
-  vprintf Shimura : "  ...Trying to MakeK with m = %o\n", m;
+intrinsic MakeKFromPoly(uCC::Any, u_pol::Any) -> Any, Any, Any, Any, Any
+  {Shared tail of MakeK: given uCC and its (already found, irreducible)
+   minimal polynomial u_pol over ZZ, build the optimized field, ramification
+   screen, and complex embedding.  Returns bl, K, v, conj, uCC.}
 
   CC := Parent(uCC);
   eps := 10^(-Precision(CC)/2);
-
-  u_pol := PowerRelation(uCC, m : Al := "LLL");
-  if Degree(u_pol) ne m or not IsIrreducible(u_pol) then
-    if Degree(u_pol) gt 1 then
-      vprint Shimura : "  ...coefficient not degree m, looked like degree", [<Degree(c[1]),c[2]> : c in Factorization(u_pol)];
-    end if;
-    return false, _, _, _, _;
+  if Degree(u_pol) eq 1 then
+    K := RationalsAsNumberField();
+    v := RealPlaces(K)[1];
+    return true, K, v, false, Parent(uCC)!1;
   end if;
   lc := LeadingCoefficient(u_pol);
   K0 := NumberField(u_pol);
@@ -202,6 +192,107 @@ intrinsic MakeK(uCC::Any, m::Any) -> Any, Any, Any, Any, Any
   v := InfinitePlaces(Kop)[vind];
   // return true, Kop, v, conj, uop;
   return true, Kop, v, conj, uCC;
+end intrinsic;
+
+intrinsic MakeK(uCC::Any, m::Any) -> Any, Any, Any, Any, Any
+  {MakeK!  What more to say?}
+
+  if m eq 1 then
+    vprint Shimura : "  ...m eq 1, so taking QQ";
+    K := RationalsAsNumberField();
+    v := RealPlaces(K)[1];
+    return true, K, v, false, Parent(uCC)!1;
+  end if;
+
+  vprintf Shimura : "  ...Trying to MakeK with m = %o\n", m;
+
+  u_pol := PowerRelation(uCC, m : Al := "LLL");
+  if Degree(u_pol) ne m or not IsIrreducible(u_pol) then
+    if Degree(u_pol) gt 1 then
+      vprint Shimura : "  ...coefficient not degree m, looked like degree", [<Degree(c[1]),c[2]> : c in Factorization(u_pol)];
+    end if;
+    return false, _, _, _, _;
+  end if;
+  return MakeKFromPoly(uCC, u_pol);
+end intrinsic;
+
+intrinsic MakeKBatch(cfs::SeqEnum, m::RngIntElt) -> Any, Any, Any, Any, Any
+  {Batched, certified replacement for the MakeK search loop, backed by the
+   external C relation finder (Cext/makek_relfinder.c, FLINT fmpz_lll).  For
+   every candidate coefficient in cfs it finds and certifies the true minimal
+   polynomial of degree <= m in a single threaded pass, then runs the usual
+   MakeK tail (ramification screen, Polredbestabs, embedding) on the best
+   candidate: largest certified degree, earliest index breaking ties.
+
+   Returns bl, K, v, conj, uCC.  bl = false means NO candidate certified any
+   relation -- with the certification in the C tool that is strong evidence
+   the working precision is insufficient (raise prec), as opposed to the
+   legacy loop which cannot distinguish "no relation" from "not enough
+   precision" and grinds through O(m * #cfs) LLL calls before failing.
+
+   Requires MAKEK_RELFINDER_BIN to point at the built binary; threads via
+   MAKEK_RELFINDER_THREADS.  File handoff mirrors the CArnoldi solver:
+   TMPDIR-respecting, random-tagged names, plain-text output (parsed, never
+   eval'd).}
+
+  cbin := GetEnv("MAKEK_RELFINDER_BIN");
+  require cbin ne "" : "MAKEK_RELFINDER_BIN is not set";
+  CC := Parent(cfs[1]);
+  precbits := Ceiling(Precision(CC)*3.3219280948873623);
+
+  tmpdir := GetEnv("TMPDIR");
+  if tmpdir eq "" then
+    tmpdir := "/tmp";
+  end if;
+  tag := Sprintf("%o_%o_%o", Getpid(), Round(1000*Realtime()) mod 10^9, Random(10^15));
+  infile := Sprintf("%o/makek_in_%o.txt", tmpdir, tag);
+  outfile := Sprintf("%o/makek_out_%o.txt", tmpdir, tag);
+
+  F := Open(infile, "w");
+  Puts(F, Sprintf("%o %o %o", precbits, #cfs, m));
+  for u in cfs do
+    Puts(F, Sprintf("%o", Real(u)));
+    Puts(F, Sprintf("%o", Imaginary(u)));
+  end for;
+  delete F;
+
+  ret := System(Sprintf("%o %o %o", cbin, infile, outfile));
+  require ret eq 0 : "external relation finder failed";
+
+  // parse: FOUND <idx> <deg> <log10resid> <c_0> ... <c_deg> | NOPREC <idx>
+  best_deg := 0; best_idx := 0; best_cfs := [];
+  done := false;
+  for line in Split(Read(outfile), "\n") do
+    parts := Split(line, " ");
+    if parts[1] eq "RELFINDER_DONE" then
+      done := true;
+    elif parts[1] eq "FOUND" then
+      idx := StringToInteger(parts[2]) + 1;  // C is 0-based
+      deg := StringToInteger(parts[3]);
+      if deg gt best_deg or (deg eq best_deg and best_deg gt 0 and idx lt best_idx) then
+        best_deg := deg;
+        best_idx := idx;
+        best_cfs := [StringToInteger(parts[k]) : k in [5..5+deg]];
+      end if;
+    end if;
+  end for;
+  require done : "external relation finder output truncated";
+  System(Sprintf("rm -f %o %o", infile, outfile));
+
+  if best_deg eq 0 then
+    vprint Shimura : "  ...MakeKBatch: no candidate certified at this precision";
+    return false, _, _, _, _;
+  end if;
+  vprintf Shimura : "  ...MakeKBatch: certified minimal polynomial of degree %o at coefficient %o\n", best_deg, best_idx;
+  uCC := cfs[best_idx];
+  if best_deg eq 1 then
+    K := RationalsAsNumberField();
+    v := RealPlaces(K)[1];
+    return true, K, v, false, Parent(uCC)!1;
+  end if;
+  ZZx<xZ> := PolynomialRing(Integers());
+  u_pol := ZZx ! best_cfs;
+  return MakeKFromPoly(uCC, u_pol);
 end intrinsic;
 
 intrinsic TriangleK(Gamma::GrpPSL2Tri) -> Any, Any, Any

--- a/Code/theta.m
+++ b/Code/theta.m
@@ -261,11 +261,14 @@ intrinsic MakeKBatch(cfs::SeqEnum, m::RngIntElt) -> Any, Any, Any, Any, Any
 
   // parse: FOUND <idx> <deg> <log10resid> <c_0> ... <c_deg> | NOPREC <idx>
   best_deg := 0; best_idx := 0; best_cfs := [];
+  nnoprec := 0;
   done := false;
   for line in Split(Read(outfile), "\n") do
     parts := Split(line, " ");
     if parts[1] eq "RELFINDER_DONE" then
       done := true;
+    elif parts[1] eq "NOPREC" then
+      nnoprec +:= 1;
     elif parts[1] eq "FOUND" then
       idx := StringToInteger(parts[2]) + 1;  // C is 0-based
       deg := StringToInteger(parts[3]);
@@ -281,6 +284,16 @@ intrinsic MakeKBatch(cfs::SeqEnum, m::RngIntElt) -> Any, Any, Any, Any, Any
 
   if best_deg eq 0 then
     vprint Shimura : "  ...MakeKBatch: no candidate certified at this precision";
+    return false, _, _, _, _;
+  end if;
+  // Guard against the trivial-rational trap: normalized coefficient lists
+  // contain exact constants (e.g. a leading 1) that certify at degree 1
+  // regardless of seed quality.  Only accept K = QQ when EVERY candidate
+  // certified; a degree-1 best alongside NOPREC candidates means the
+  // interesting coefficients could not be certified -- report failure so
+  // the caller raises precision instead of building a wrong map.
+  if best_deg eq 1 and nnoprec gt 0 then
+    vprintf Shimura : "  ...MakeKBatch: only trivial degree-1 certifications (%o candidates NOPREC) -- insufficient precision\n", nnoprec;
     return false, _, _, _, _;
   end if;
   vprintf Shimura : "  ...MakeKBatch: certified minimal polynomial of degree %o at coefficient %o\n", best_deg, best_idx;

--- a/README.md
+++ b/README.md
@@ -84,6 +84,34 @@ in ~23 s with the C solver versus ~170 s without, on a 16-core machine.
 Implementation notes, the input/output file formats, and numerical details
 are documented in `Cext/README.md`.
 
+## Fast certified recognition for MakeK (number field of the Belyi map)
+
+After the numerical solve, `BelyiMap` must recognize the coefficient field
+K from complex approximations (`MakeK` in `Code/theta.m`).  The legacy
+search calls Magma's `PowerRelation` once per (coefficient, degree) pair —
+up to `passport size x #coefficients` sequential LLL calls, each of which
+can take minutes at high precision — and when the working precision is too
+low to certify any relation it grinds through the entire loop before
+failing (observed: 15+ CPU-hours of doomed `MakeK` calls on an M24 genus-0
+run at `prec := 400`).
+
+`Cext/makek_relfinder` replaces the loop with one batched, threaded pass:
+a single `fmpz_lll` integer-relation reduction per coefficient at the
+passport degree bound, followed by `fmpz_poly_factor` and an arb-certified
+check of which irreducible factor actually vanishes at the coefficient.
+The true minimal polynomial of any degree up to the bound falls out
+directly; if nothing certifies, the run aborts within seconds with an
+explicit "raise prec" error instead of days of grinding.
+
+Build it with the same `make` as above, then:
+```
+export MAKEK_RELFINDER_BIN=/path/to/Belyi/Cext/makek_relfinder
+export MAKEK_RELFINDER_THREADS=8
+```
+The batched path is used by the genus-0 recognition stage whenever
+`MAKEK_RELFINDER_BIN` is set; unset it to fall back to the legacy search,
+which is unchanged and remains the default.
+
 ## Tests
 
 ```

--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ The batched path is used by the genus-0 recognition stage whenever
 `MAKEK_RELFINDER_BIN` is set; unset it to fall back to the legacy search,
 which is unchanged and remains the default.
 
+The same binary's `--overk` mode accelerates the follow-on stage,
+`RecognizeOverK` (expressing every remaining coefficient over the found
+field K): the integral-basis lattice is LLL-reduced once and each
+coefficient is then a small certified reduction against it, with the same
+denominator chaining as the legacy loop and a certified abort ("increase
+prec") in place of the legacy fatal error deep into the run.  Gated by the
+same environment variable.
+
 ## Tests
 
 ```

--- a/Tests/run_tests.sh
+++ b/Tests/run_tests.sh
@@ -5,33 +5,46 @@
 cd "$(dirname "$0")/.." || exit 1
 FAILED=0
 
-# ---- 1. C solver selftest -------------------------------------------------
+# ---- 1. C solver selftests ------------------------------------------------
 BIN=${POWSER_ARNOLDI_BIN:-Cext/powser_arnoldi}
-# always invoke make (not only when the binary is missing): make no-ops when
-# the binary is up to date, and a stale binary from an older checkout
+MBIN=${MAKEK_RELFINDER_BIN:-Cext/makek_relfinder}
+# always invoke make (not only when a binary is missing): make no-ops when
+# the binaries are up to date, and a stale binary from an older checkout
 # silently reintroduces already-fixed bugs (observed: a pre-p-notation
-# binary truncating all solver output to 30 digits).  An explicitly set
-# POWSER_ARNOLDI_BIN is respected and never rebuilt.
-if [ -z "${POWSER_ARNOLDI_BIN:-}" ] && command -v make >/dev/null 2>&1; then
-    (cd Cext && { make powser_arnoldi >/dev/null 2>&1 || make mac >/dev/null 2>&1; })
+# binary truncating all solver output to 30 digits).  Explicitly set
+# POWSER_ARNOLDI_BIN / MAKEK_RELFINDER_BIN are respected and never rebuilt.
+if { [ -z "${POWSER_ARNOLDI_BIN:-}" ] || [ -z "${MAKEK_RELFINDER_BIN:-}" ]; } \
+   && command -v make >/dev/null 2>&1; then
+    (cd Cext && { make >/dev/null 2>&1 || make mac >/dev/null 2>&1; })
 fi
-# export an absolute path so the Magma tests (which read POWSER_ARNOLDI_BIN
-# via GetEnv) actually use the binary we just built, instead of silently
-# SKIPping when nothing named powser_arnoldi is on PATH
+# export absolute paths so the Magma tests (which read these variables via
+# GetEnv) actually use the binaries we just built, instead of silently
+# SKIPping when nothing is on PATH
 if [ -x "$BIN" ]; then
     POWSER_ARNOLDI_BIN="$(cd "$(dirname "$BIN")" && pwd)/$(basename "$BIN")"
     export POWSER_ARNOLDI_BIN
 fi
-if [ -x "$BIN" ]; then
-    if "$BIN" --selftest 2>&1 | grep -q "SELFTEST PASSED"; then
-        echo "PASS: C solver selftest"
-    else
-        echo "FAIL: C solver selftest"
-        FAILED=1
-    fi
-else
-    echo "SKIP: C solver selftest (no binary; build Cext/powser_arnoldi)"
+if [ -x "$MBIN" ]; then
+    MAKEK_RELFINDER_BIN="$(cd "$(dirname "$MBIN")" && pwd)/$(basename "$MBIN")"
+    export MAKEK_RELFINDER_BIN
 fi
+
+selftest() {
+    name=$1
+    bin=$2
+    if [ -x "$bin" ]; then
+        if "$bin" --selftest 2>&1 | grep -q "SELFTEST PASSED"; then
+            echo "PASS: $name selftest"
+        else
+            echo "FAIL: $name selftest"
+            FAILED=1
+        fi
+    else
+        echo "SKIP: $name selftest (no binary; build Cext/$name)"
+    fi
+}
+selftest powser_arnoldi "$BIN"
+selftest makek_relfinder "$MBIN"
 
 # ---- 2. Magma tests -------------------------------------------------------
 if ! command -v magma >/dev/null 2>&1; then
@@ -39,27 +52,44 @@ if ! command -v magma >/dev/null 2>&1; then
     exit $FAILED
 fi
 
+# run_magma_test <file> [legacy]
+# "legacy" runs with MAKEK_RELFINDER_BIN emptied, exercising the pure-Magma
+# recognition path even when the batched FLINT binary is available
 run_magma_test() {
     f=$1
+    mode=${2:-}
+    tag=""
     # stdin from /dev/null: if a test errors into an interactive or debugger
     # prompt instead of quitting, it terminates on EOF rather than hanging
     # the runner with its output swallowed by the capture
-    out=$(magma -b "$f" 2>&1 </dev/null)
+    if [ "$mode" = "legacy" ]; then
+        tag=" (legacy MakeK)"
+        out=$(env MAKEK_RELFINDER_BIN= magma -b "$f" 2>&1 </dev/null)
+    else
+        out=$(magma -b "$f" 2>&1 </dev/null)
+    fi
     if echo "$out" | grep -q "ALL TESTS PASSED"; then
-        echo "PASS: $f"
+        echo "PASS: $f$tag"
     elif echo "$out" | grep -q "^SKIP"; then
         echo "$out" | grep "^SKIP" | head -1
     else
-        echo "FAIL: $f"
+        echo "FAIL: $f$tag"
         echo "$out" | tail -25
         FAILED=1
     fi
 }
 
 run_magma_test Tests/test_basic_belyi.m
+# with the binary exported above, the run above exercises the batched FLINT
+# recognition; rerun through the legacy pure-Magma MakeK so BOTH paths stay
+# covered (skipped when no binary: then the run above already was legacy)
+if [ -n "${MAKEK_RELFINDER_BIN:-}" ]; then
+    run_magma_test Tests/test_basic_belyi.m legacy
+fi
 run_magma_test Tests/test_carnoldi_belyi.m
 run_magma_test Tests/test_genusone_extra_zero.m
 run_magma_test Tests/test_genusone_aj.m
+run_magma_test Tests/test_makek_relfinder.m
 if [ -n "$RUNSLOW" ]; then
     run_magma_test Tests/test_powser_consistency.m
 else

--- a/Tests/run_tests.sh
+++ b/Tests/run_tests.sh
@@ -5,27 +5,49 @@
 cd "$(dirname "$0")/.." || exit 1
 FAILED=0
 
-# ---- 1. C solver selftest -------------------------------------------------
+# ---- 1. C solver selftests ------------------------------------------------
+build_cext() {
+    if command -v make >/dev/null 2>&1; then
+        (cd Cext && make all >/dev/null 2>&1) || (cd Cext && make mac >/dev/null 2>&1) || true
+    fi
+}
+
 BIN=${POWSER_ARNOLDI_BIN:-Cext/powser_arnoldi}
-if [ ! -x "$BIN" ] && command -v make >/dev/null 2>&1; then
-    (cd Cext && make powser_arnoldi >/dev/null 2>&1 || make mac >/dev/null 2>&1)
+RELFINDER=${MAKEK_RELFINDER_BIN:-Cext/makek_relfinder}
+if [ ! -x "$BIN" ] || [ ! -x "$RELFINDER" ]; then
+    build_cext
 fi
-# export an absolute path so the Magma tests (which read POWSER_ARNOLDI_BIN
-# via GetEnv) actually use the binary we just built, instead of silently
-# SKIPping when nothing named powser_arnoldi is on PATH
+# export absolute paths so Magma tests (which read via GetEnv) actually use
+# the binaries we just built, instead of silently falling back to legacy
 if [ -x "$BIN" ]; then
     POWSER_ARNOLDI_BIN="$(cd "$(dirname "$BIN")" && pwd)/$(basename "$BIN")"
     export POWSER_ARNOLDI_BIN
 fi
-if [ -x "$BIN" ]; then
-    if "$BIN" --selftest 2>&1 | grep -q "SELFTEST PASSED"; then
-        echo "PASS: C solver selftest"
+if [ -x "$RELFINDER" ]; then
+    MAKEK_RELFINDER_BIN="$(cd "$(dirname "$RELFINDER")" && pwd)/$(basename "$RELFINDER")"
+    export MAKEK_RELFINDER_BIN
+fi
+
+if [ -x "${POWSER_ARNOLDI_BIN:-$BIN}" ]; then
+    if "$POWSER_ARNOLDI_BIN" --selftest 2>&1 | grep -q "SELFTEST PASSED"; then
+        echo "PASS: C powser_arnoldi selftest"
     else
-        echo "FAIL: C solver selftest"
+        echo "FAIL: C powser_arnoldi selftest"
         FAILED=1
     fi
 else
-    echo "SKIP: C solver selftest (no binary; build Cext/powser_arnoldi)"
+    echo "SKIP: C powser_arnoldi selftest (no binary; build Cext/powser_arnoldi)"
+fi
+
+if [ -x "${MAKEK_RELFINDER_BIN:-$RELFINDER}" ]; then
+    if "$MAKEK_RELFINDER_BIN" --selftest 2>&1 | grep -q "SELFTEST PASSED"; then
+        echo "PASS: C makek_relfinder selftest"
+    else
+        echo "FAIL: C makek_relfinder selftest"
+        FAILED=1
+    fi
+else
+    echo "SKIP: C makek_relfinder selftest (no binary; build Cext/makek_relfinder)"
 fi
 
 # ---- 2. Magma tests -------------------------------------------------------
@@ -54,6 +76,13 @@ run_magma_test() {
 run_magma_test Tests/test_basic_belyi.m
 run_magma_test Tests/test_carnoldi_belyi.m
 run_magma_test Tests/test_genusone_extra_zero.m
+if [ -n "$MAKEK_RELFINDER_BIN" ] && [ -x "$MAKEK_RELFINDER_BIN" ]; then
+    run_magma_test Tests/test_makek_relfinder.m
+    run_magma_test Tests/test_certified_belyi.m
+else
+    echo "SKIP: Tests/test_makek_relfinder.m (no MAKEK_RELFINDER_BIN)"
+    echo "SKIP: Tests/test_certified_belyi.m (no MAKEK_RELFINDER_BIN)"
+fi
 if [ -n "$RUNSLOW" ]; then
     run_magma_test Tests/test_powser_consistency.m
 else

--- a/Tests/test_certified_belyi.m
+++ b/Tests/test_certified_belyi.m
@@ -1,0 +1,37 @@
+// End-to-end Belyi map computations through the CERTIFIED recognition path
+// (ExactAl := "Certified" / MAKEK_RELFINDER_BIN), including a map NOT
+// defined over QQ.  Requires the built Cext/makek_relfinder binary:
+//
+//   MAKEK_RELFINDER_BIN=$PWD/Cext/makek_relfinder magma -b Tests/test_certified_belyi.m
+
+AttachSpec("MagmaPolred/spec");
+AttachSpec("Code/spec");
+
+assert GetEnv("MAKEK_RELFINDER_BIN") ne "";
+
+// ---- 1: genus 0, hyperbolic, defined over QQ (LMFDB 5T4-5_3.1.1_3.1.1-a):
+// exercises MakeKBatch (field recognition) and the batched RecognizeOverK
+// through the genus-0 Newton pipeline.
+sigma1 := [Sym(5) | (1,3,2,5,4), (1,2,3), (1,4,5)];
+X1, phi1 := BelyiMap(sigma1 : prec := 40, ExactAl := "Certified");
+assert BelyiMapSanityCheck(sigma1, X1, phi1);
+assert Degree(BaseRing(X1)) eq 1;
+print "test 1 ok: genus-0 over QQ via certified path";
+
+// ---- 2: genus 0 hyperbolic, degree 6, base field QQ(sqrt 10)
+// (LMFDB 6T15-5.1_4.2_3.1.1.1-a, orbit size 2): a map NOT defined over QQ;
+// exercises the certified field recognition (MakeKBatch finds the quadratic
+// field) and the batched certified RecognizeOverK over it.
+S6 := Sym(6);
+sigma2 := [S6 | S6![2,4,3,5,6,1], S6![3,6,1,2,4,5], S6![2,3,1,4,5,6]];
+assert sigma2[3]*sigma2[2]*sigma2[1] eq Id(S6);
+X2, phi2 := BelyiMap(sigma2 : prec := 60, ExactAl := "Certified");
+assert BelyiMapSanityCheck(sigma2, X2, phi2);
+K2 := BaseRing(X2);
+assert Degree(K2) eq 2;
+R<x> := PolynomialRing(Rationals());
+assert IsIsomorphic(NumberField(R!DefiningPolynomial(K2)), NumberField(x^2 - 10));
+print "test 2 ok: genus-0 over QQ(sqrt 10) via certified path";
+
+print "ALL TESTS PASSED";
+exit;

--- a/Tests/test_certified_belyi.m
+++ b/Tests/test_certified_belyi.m
@@ -33,5 +33,19 @@ R<x> := PolynomialRing(Rationals());
 assert IsIsomorphic(NumberField(R!DefiningPolynomial(K2)), NumberField(x^2 - 10));
 print "test 2 ok: genus-0 over QQ(sqrt 10) via certified path";
 
+// ---- 3: genus 0, degree 6, base field of degree 4
+// (LMFDB 6T16-4.2_3.2.1_3.2.1-a, orbit size 4; suggested by SamSchiavone):
+// certified recognition of a quartic field through the genus-0 pipeline.
+// LMFDB base field: x^4 - 2x^3 - 3x^2 + 4x - 2.
+sigma3 := [S6 | S6![4,6,1,5,3,2], S6![2,3,1,5,4,6], S6![2,6,4,3,5,1]];
+assert sigma3[3]*sigma3[2]*sigma3[1] eq Id(S6);
+X3, phi3 := BelyiMap(sigma3 : prec := 80, ExactAl := "Certified");
+assert BelyiMapSanityCheck(sigma3, X3, phi3);
+K3 := BaseRing(X3);
+assert Degree(K3) eq 4;
+assert IsIsomorphic(NumberField(R!DefiningPolynomial(K3)),
+                    NumberField(x^4 - 2*x^3 - 3*x^2 + 4*x - 2));
+print "test 3 ok: genus-0 over a quartic field via certified path";
+
 print "ALL TESTS PASSED";
 exit;

--- a/Tests/test_certified_belyi.m
+++ b/Tests/test_certified_belyi.m
@@ -4,10 +4,13 @@
 //
 //   MAKEK_RELFINDER_BIN=$PWD/Cext/makek_relfinder magma -b Tests/test_certified_belyi.m
 
+if GetEnv("MAKEK_RELFINDER_BIN") eq "" then
+  print "SKIP: makek_relfinder binary not found (set MAKEK_RELFINDER_BIN)";
+  quit;
+end if;
+
 AttachSpec("MagmaPolred/spec");
 AttachSpec("Code/spec");
-
-assert GetEnv("MAKEK_RELFINDER_BIN") ne "";
 
 // ---- 1: genus 0, hyperbolic, defined over QQ (LMFDB 5T4-5_3.1.1_3.1.1-a):
 // exercises MakeKBatch (field recognition) and the batched RecognizeOverK
@@ -46,6 +49,16 @@ assert Degree(K3) eq 4;
 assert IsIsomorphic(NumberField(R!DefiningPolynomial(K3)),
                     NumberField(x^4 - 2*x^3 - 3*x^2 + 4*x - 2));
 print "test 3 ok: genus-0 over a quartic field via certified path";
+
+// ---- 4: same map as test 1, but through the BelyiMap(Gamma) overload:
+// ExactAl := "Certified" was originally honored only by the sigma overload
+// and silently ignored elsewhere; this pins the require-and-remap on the
+// Gamma entry point (the sigmas overload forwards to Gammas, which remaps).
+Gamma4 := TriangleSubgroup(sigma1);
+X4, phi4 := BelyiMap(Gamma4 : prec := 40, ExactAl := "Certified");
+assert BelyiMapSanityCheck(sigma1, X4, phi4);
+assert Degree(BaseRing(X4)) eq 1;
+print "test 4 ok: certified path via the Gamma overload";
 
 print "ALL TESTS PASSED";
 exit;

--- a/Tests/test_makek_relfinder.m
+++ b/Tests/test_makek_relfinder.m
@@ -4,10 +4,13 @@
 //
 //   MAKEK_RELFINDER_BIN=$PWD/Cext/makek_relfinder magma -b Tests/test_makek_relfinder.m
 
+if GetEnv("MAKEK_RELFINDER_BIN") eq "" then
+  print "SKIP: makek_relfinder binary not found (set MAKEK_RELFINDER_BIN)";
+  quit;
+end if;
+
 AttachSpec("MagmaPolred/spec");
 AttachSpec("Code/spec");
-
-assert GetEnv("MAKEK_RELFINDER_BIN") ne "";
 
 // ---- 1: mixed batch at generous precision: the sqrt(5)-side coefficient
 // must be certified at degree 2, the rational one at degree 1, and the

--- a/Tests/test_makek_relfinder.m
+++ b/Tests/test_makek_relfinder.m
@@ -1,0 +1,42 @@
+// Test the batched certified recognition path (MakeKBatch backed by
+// Cext/makek_relfinder) against known algebraic numbers, and check the
+// insufficient-precision verdict.  Requires MAKEK_RELFINDER_BIN.
+//
+//   MAKEK_RELFINDER_BIN=$PWD/Cext/makek_relfinder magma -b Tests/test_makek_relfinder.m
+
+AttachSpec("MagmaPolred/spec");
+AttachSpec("Code/spec");
+
+assert GetEnv("MAKEK_RELFINDER_BIN") ne "";
+
+// ---- 1: mixed batch at generous precision: the sqrt(5)-side coefficient
+// must be certified at degree 2, the rational one at degree 1, and the
+// best (largest-degree) pick must be the degree-6 generator.
+CC<i> := ComplexField(400);
+// u6 = 2^(1/3) + 5^(1/2) generates a degree-6 field
+u6 := CC ! (2^(CC!1/3) + Sqrt(CC!5));
+u2 := CC ! ((1 + Sqrt(CC!(-7)))/2);
+u1 := CC ! (22/7);
+cfs := [u2, u1, u6];
+
+bl, K, v, conj, uCC := MakeKBatch(cfs, 12);
+assert bl;
+assert Degree(K) eq 6;               // largest certified degree wins
+assert Abs(Evaluate(K.1, v : Precision := 30)) ge 0;  // embedding exists
+print "test 1 ok: degree-6 generator picked from mixed batch";
+
+// ---- 2: batch with only low-degree entries picks the largest of those
+bl, K2, v2, conj2, uCC2 := MakeKBatch([u1, u2], 12);
+assert bl;
+assert Degree(K2) eq 2;
+print "test 2 ok: degree-2 pick";
+
+// ---- 3: starved precision certifies nothing (and must NOT hand back junk)
+CClow := ComplexField(30);
+w := CClow ! ((100003)^(CClow!1/8) * 2^(CClow!1/3));  // deg-24 minpoly, heights >> 30 digits
+bl3 := MakeKBatch([w], 24);
+assert not bl3;
+print "test 3 ok: starved precision -> bl = false";
+
+print "ALL TESTS PASSED";
+exit;

--- a/Tests/test_makek_relfinder.m
+++ b/Tests/test_makek_relfinder.m
@@ -38,5 +38,30 @@ bl3 := MakeKBatch([w], 24);
 assert not bl3;
 print "test 3 ok: starved precision -> bl = false";
 
+// ---- 4: RecognizeOverK batch path: known elements of Q(sqrt5) recovered
+// exactly, with denominator chaining across the sequence
+R<x> := PolynomialRing(Rationals());
+K5 := NumberField(x^2 - x - 1);   // ZK basis 1, phi
+v5 := InfinitePlaces(K5)[2];      // phi -> golden ratio (positive root)
+if Abs(Evaluate(K5.1, v5 : Precision := 30) - 1.618) gt 0.01 then
+  v5 := InfinitePlaces(K5)[1];
+end if;
+els := [ K5 | (3 + 7*K5.1)/5, (-2 + 9*K5.1)/40, 11/3 ];
+CCr := ComplexField(200);
+targets := [ CCr!Evaluate(e, v5 : Precision := 200) : e in els ];
+out := RecognizeOverK([targets], K5, v5, false);
+assert out[1] eq els;
+print "test 4 ok: RecognizeOverK batch recovers exact elements";
+
+// ---- 5: a non-element in the sequence must raise the certified error
+ok5 := false;
+try
+  _ := RecognizeOverK([[CCr!Pi(CCr)]], K5, v5, false);
+catch e
+  ok5 := true;
+end try;
+assert ok5;
+print "test 5 ok: non-element -> certified error";
+
 print "ALL TESTS PASSED";
 exit;


### PR DESCRIPTION
## Summary

Companion to #36, targeting the stage that becomes the bottleneck once the power-series basis is fast: recognizing the Belyi map's coefficient field from complex approximations (`MakeK`).

The legacy genus-0 search calls `PowerRelation` once per (coefficient, degree) pair — up to `passport_size × #coefficients` sequential Magma LLL calls, each of which takes minutes at high precision. Worse, when the working precision cannot certify any relation the loop has no way to know: it grinds through the whole schedule before failing. Motivating data from an M24 genus-0 run (degree 24, `prec := 400`, verbose log): **134 MakeK calls over 15+ CPU-hours, none of which could ever succeed** — the coefficient field has degree ~12 with heights far beyond what 400 digits can certify; the run had to be killed.

## What this PR does

`Cext/makek_relfinder.c` (FLINT ≥ 3.0, same dependency set as #36) replaces the loop with **one batched, threaded pass**:

- per candidate coefficient, a single `fmpz_lll` integer-relation reduction at the passport degree bound — no per-degree scanning;
- `fmpz_poly_factor` on the relation, then an **arb-certified** check of which irreducible factor actually vanishes at the coefficient: the true minimal polynomial of any degree ≤ bound falls out directly;
- candidates whose relations cannot be certified are reported `NOPREC`, so `BelyiMap` aborts within seconds with an explicit *raise prec* error instead of days of grinding.

Magma side: `MakeK`'s post-LLL tail is factored into `MakeKFromPoly` (shared, behavior identical); new `MakeKBatch` intrinsic does the file handoff (TMPDIR-respecting, random-tagged names, plain-text output that is parsed — never `eval`'d); the genus-0 recognition branch in `genuszero.m` uses it when `MAKEK_RELFINDER_BIN` is set. **The legacy path is unchanged and remains the default.**

```
export MAKEK_RELFINDER_BIN=/path/to/Belyi/Cext/makek_relfinder
export MAKEK_RELFINDER_THREADS=8
```

## Correctness

- C selftest: recognizes a degree-6 minimal polynomial at bound 12 (residual ~1e-417), a complex quadratic, and — the key property — returns `NOPREC` rather than junk on a starved-precision input.
- `Tests/test_makek_relfinder.m`: Magma-glue tests (largest-certified-degree selection, degree-1/2 cases, starved-precision failure).
- `Tests/test_basic_belyi.m` passes both **with and without** the env var (the A5 genus-0 hyperbolic example exercises the new branch end-to-end, verified by `BelyiMapSanityCheck`).
- CI extended to build and selftest both binaries under gcc and clang.

## Not in this PR (follow-ups)

- `RecognizeOverK` (recognition of the remaining coefficients over the found K) has the same shape and would benefit from the same treatment — it is the observed failure point on other runs ("Insufficient precision in RecognizeOverK").
- The genus-1/hyperelliptic recognition loops (`newton.m`, `newton_hyperelliptic.m`, `recognition.m`) still use per-call `MakeK`; they can adopt `MakeKBatch` with the same gating once the genus-0 path has burned in.
- The `TrialDivision(Discriminant(K))` ramification screen in the shared tail forces a maximal-order computation that can itself be very expensive for large candidate fields; a poldisc-based screen is a candidate refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)