### PR TITLE
Common zero fix

### DIFF
--- a/Code/genusone.m
+++ b/Code/genusone.m
@@ -288,8 +288,10 @@ intrinsic TriangleAJSegment(aCC::FldComElt, bCC::FldComElt, Gamma::GrpPSL2Tri, S
       mred, delta := FDReduce(DD!((p+q)/2), Gamma);
       // convention check: delta must be the element carrying the input to
       // the reduced point (fires loudly if FDReduce's return order or
-      // action direction ever changes)
-      assert Abs(ComplexValue(delta*(DD!((p+q)/2))) - ComplexValue(mred)) lt 10^(-10);
+      // action direction ever changes).  This is a binary discrimination --
+      // right convention agrees to ~10^(-prec), wrong convention differs by
+      // O(1) -- so any threshold in the gap works; use eps = 10^(-prec/2).
+      assert Abs(ComplexValue(delta*(DD!((p+q)/2))) - ComplexValue(mred)) lt eps;
       pr := DiscToPlane(UU, delta*(DD!p));
       qr := DiscToPlane(UU, delta*(DD!q));
       jj := 1;
@@ -403,7 +405,7 @@ intrinsic TriangleAJToEllipticCurve(w_CC::FldComElt, Gamma::GrpPSL2Tri, x::RngSe
   return TriangleComplexPlaneToEllipticCurve(w_CC, Gamma, x, y);
 end intrinsic;
 
-intrinsic TriangleDiscToEllipticCurve(w::SpcHydElt, Gamma::GrpPSL2Tri, Sk::SeqEnum, x::RngSerLaurElt, y::RngSerLaurElt) -> GenerateLSpaceBasisAnalytic
+intrinsic TriangleDiscToEllipticCurve(w::SpcHydElt, Gamma::GrpPSL2Tri, Sk::SeqEnum, x::RngSerLaurElt, y::RngSerLaurElt) -> Any
   {Given an element w of the hyperbolic disc, outputs the corresponding point on the elliptic curve associated to Gamma.}
 
   assert Genus(Gamma) eq 1;

--- a/Code/genusone.m
+++ b/Code/genusone.m
@@ -274,74 +274,69 @@ intrinsic TriangleDiscToComplexPlane(w::SpcHydElt, Gamma::GrpPSL2Tri, Sk::SeqEnu
     Sk1[j] := Sk1[j]*2*I*Im(centers[j]);
   end for;
   Sk1int := [Integral(f) : f in Sk1];
-  // The previous implementation evaluated Sk1int[1] at w regardless of where
+  // The original implementation evaluated Sk1int[1] at w regardless of where
   // w lies; for w far from the first center -- e.g. the fundamental domain
   // vertices, which is exactly where the ramification points live -- the
   // truncation error of an N-term expansion grows like (|w|/rho)^N and
   // destroyed most of the working precision (ramification points came out
-  // with ~5 correct digits at prec 100).  Instead: FDReduce w into the chart
-  // of its nearest expansion center (a Gamma-translate, which shifts the
-  // integral by a period -- harmless mod Lambda) and integrate with that
-  // center's expansion, exactly as the period computation below already does
-  // chart by chart.  The integration constants K_j = int_{c_1}^{c_j} f dz are
-  // chained through pairwise chart-overlap midpoints, so that every series
-  // evaluation happens well inside a disc of convergence.
+  // with ~5 correct digits at prec 100).  Instead, integrate the invariant
+  // differential f dz along the straight segment from 0 to w in the disc,
+  // adaptively subdivided until each piece -- after transporting it into the
+  // fundamental domain by a group element, which leaves the integral of a
+  // Gamma-invariant form unchanged -- fits well inside SOME expansion chart.
+  // This is the same chart-by-chart pattern the period computation below has
+  // always used, and unlike chaining charts through single overlap
+  // midpoints, it makes no assumption about how the charts are laid out.
   Delta := ContainingTriangleGroup(Gamma);
   rho := Max([Abs(z) : z in FundamentalDomain(Delta, DD)]);
   eps := (RealField(CC)!10)^(-prec/2);
   UU := UpperHalfPlane();
   nv := #Sk1;
-  czs := [UU!ComplexValue(Center(D)) : D in DDs];
   locc := function(z, j)  // local coordinate (a complex number) of the UHP point z in chart j
     return ComplexValue(PlaneToDisc(DDs[j], z));
   end function;
-  // chain the integration constants K_j from center 1 by a greedy tree
-  K := [CC | 0 : j in [1..nv]];
-  done := [j eq 1 : j in [1..nv]];
-  for count in [2..nv] do
-    bestr := RealField(CC)!2;
-    besti := 0; bestj := 0;
-    bestm := DiscToPlane(UU, DD!0);
-    for j in [1..nv] do
-      if done[j] then continue; end if;
-      for i in [1..nv] do
-        if not done[i] then continue; end if;
-        m := DiscToPlane(UU, DDs[i]!(locc(czs[j], i)/2));  // midpoint of c_i, c_j in chart i
-        r := Max(Abs(locc(m, i)), Abs(locc(m, j)));
-        if r lt bestr then
-          bestr := r; besti := i; bestj := j; bestm := m;
+  segint := function(aCC, bCC)  // integral of f dz from aCC to bCC (disc coordinates)
+    k := 1;
+    repeat
+      ok := true;
+      total := CC!0;
+      for l in [0..k-1] do
+        p := aCC + (bCC-aCC)*l/k;
+        q := aCC + (bCC-aCC)*(l+1)/k;
+        // transport this piece into the fundamental domain by the element
+        // reducing its midpoint; both endpoints ride along, so the piece
+        // stays contiguous and its integral is unchanged (f dz is invariant)
+        mred, delta := FDReduce(DD!((p+q)/2), Gamma);
+        // convention check: delta must be the element carrying the input to
+        // the reduced point (fires loudly if FDReduce's return order or
+        // action direction ever changes)
+        assert Abs(ComplexValue(delta*(DD!((p+q)/2))) - ComplexValue(mred)) lt 10^(-10);
+        pr := DiscToPlane(UU, delta*(DD!p));
+        qr := DiscToPlane(UU, delta*(DD!q));
+        // best chart for this piece
+        jj := 1;
+        best := Max(Abs(locc(pr, 1)), Abs(locc(qr, 1)));
+        for j in [2..nv] do
+          r := Max(Abs(locc(pr, j)), Abs(locc(qr, j)));
+          if r lt best then
+            best := r; jj := j;
+          end if;
+        end for;
+        if best ge rho + eps then  // piece too coarse: subdivide further
+          ok := false;
+          break;
         end if;
+        total +:= Evaluate(Sk1int[jj], locc(qr, jj)) - Evaluate(Sk1int[jj], locc(pr, jj));
       end for;
-    end for;
-    error if bestr ge rho + eps,
-      "cannot chain expansion centers: best chart-overlap midpoint lies outside rho";
-    K[bestj] := K[besti]
-      + Evaluate(Sk1int[besti], locc(bestm, besti)) - Evaluate(Sk1int[besti], CC!0)
-      + Evaluate(Sk1int[bestj], CC!0) - Evaluate(Sk1int[bestj], locc(bestm, bestj));
-    done[bestj] := true;
-  end for;
-  // Abel-Jacobi value of a disc point via its nearest chart.  (Do NOT trust
-  // whichcoset to name the nearest chart: it is built for the reduction
-  // machinery's own inputs, and e.g. for interior points like the base point
-  // DD!0 the assigned chart can lie farther than rho.  Any chart with a
-  // small local coordinate is equally correct once the constants K_j are in
-  // place, so choose by explicit minimization.)
-  ajval := function(v)
-    vp := FDReduce(v, Gamma);  // Gamma-translate into the FD: shifts the integral by a period
-    z := DiscToPlane(UU, vp);
-    jj := 1;
-    best := Abs(locc(z, 1));
-    for j in [2..nv] do
-      r := Abs(locc(z, j));
-      if r lt best then
-        best := r; jj := j;
+      if not ok then
+        k *:= 2;
+        error if k gt 1024,
+          "integration path cannot be covered by the expansion charts even after 1024 subdivisions";
       end if;
-    end for;
-    error if best ge rho + eps,
-      "point is not covered by any expansion chart: nearest local coordinate has absolute value", best, "vs rho =", rho;
-    return K[jj] + Evaluate(Sk1int[jj], locc(z, jj)) - Evaluate(Sk1int[jj], CC!0);
+    until ok;
+    return total;
   end function;
-  w_CC := ajval(w) - ajval(DD!0); // CC mod Lambda
+  w_CC := segint(CC!0, ComplexValue(w));
   return w_CC;
 end intrinsic;
 
@@ -381,26 +376,92 @@ intrinsic TriangleComplexPlaneToEllipticCurve(c::FldComElt, Gamma::GrpPSL2Tri, x
   return c_E;
 end intrinsic;
 
-intrinsic TriangleDiscToEllipticCurve(w::SpcHydElt, Gamma::GrpPSL2Tri, Sk::SeqEnum, x::RngSerLaurElt, y::RngSerLaurElt) -> GenerateLSpaceBasisAnalytic
-  {Given an element w of the hyperbolic disc, outputs the corresponding point on the elliptic curve associated to Gamma.}
+intrinsic TriangleAJToEllipticCurve(w_CC::FldComElt, Gamma::GrpPSL2Tri, x::RngSerLaurElt, y::RngSerLaurElt) -> Any
+  {Given an Abel-Jacobi value w_CC in CC, reduce it mod the period lattice to
+   a smallest representative, check it is not a pole, and return the
+   corresponding point [x, y] on the elliptic curve associated to Gamma.}
 
   assert Genus(Gamma) eq 1;
-  prec := Precision(BaseRing(Parent(Sk[1][1])));  // coefficient precision, not series length
-  w_CC := TriangleDiscToComplexPlane(w, Gamma, Sk);
-  // reduce mod Lambda to a smallest representative: the nearest-chart
-  // evaluation returns w_CC only up to a period, and the pole test must
-  // catch every lattice translate of 0 (this resolves the old TODO); the
-  // periods are chart-by-chart integrals, accurate to working precision
+  prec := Precision(Parent(w_CC));
+  // the periods are chart-by-chart integrals, accurate to working precision,
+  // and the reduction makes the pole test catch every lattice translate of 0
   Lambda := Gamma`TrianglePeriodLattice;
   M := Matrix([[Re(l), Im(l)] : l in Lambda]);
   sol := Solution(M, Vector([Re(w_CC), Im(w_CC)]));
   w_CC := w_CC - Round(sol[1])*Lambda[1] - Round(sol[2])*Lambda[2];
-  if Abs(w_CC) lt 10^(-prec/2) then
+  if Abs(w_CC) lt 10^(-(prec div 2)) then
     error "w_CC is a pole of wp!";
-  else
-    w_E := TriangleComplexPlaneToEllipticCurve(w_CC, Gamma, x, y);
   end if;
-  return w_E;
+  return TriangleComplexPlaneToEllipticCurve(w_CC, Gamma, x, y);
+end intrinsic;
+
+intrinsic TriangleDiscToEllipticCurve(w::SpcHydElt, Gamma::GrpPSL2Tri, Sk::SeqEnum, x::RngSerLaurElt, y::RngSerLaurElt) -> GenerateLSpaceBasisAnalytic
+  {Given an element w of the hyperbolic disc, outputs the corresponding point on the elliptic curve associated to Gamma.}
+
+  assert Genus(Gamma) eq 1;
+  w_CC := TriangleDiscToComplexPlane(w, Gamma, Sk);
+  return TriangleAJToEllipticCurve(w_CC, Gamma, x, y);
+end intrinsic;
+
+intrinsic TriangleCosetVertexToComplexPlane(ind::RngIntElt, vi::RngIntElt, Gamma::GrpPSL2Tri, Sk::SeqEnum) -> Any
+  {Abel-Jacobi image in CC of the fundamental domain vertex
+   alphas[ind]*V[vi], where V = [w_a, w_c, w_b, w_cbar] is the fundamental
+   domain of the containing triangle group and alphas the coset
+   representatives.  Computed EXACTLY (no reduction, no mod-Lambda slack) by
+   integrating chart by chart along the coset-graph path from the identity
+   to alphas[ind], as in the period computation: the coset labels produced
+   by the enumeration (KMSV Algorithms 3.5/3.8) are prefix-closed, so every
+   partial word of alphas[ind] is itself a coset representative, consecutive
+   translates of the fundamental triangle are adjacent, and each step
+   integrates between alpha0*v and alpha1*v inside the chart of the new
+   coset.  The base point is w_a = 0 (the disc is centered at z_a).}
+
+  assert Genus(Gamma) eq 1;
+  prec := Precision(BaseRing(Parent(Sk[1][1])));
+  Sk1 := Sk[1];
+  CC<I> := BaseRing(Parent(Sk[1][1]));
+  DDs := Gamma`TriangleDDs;
+  centers := [ComplexValue(Center(D)) : D in DDs];
+  for j in [1..#Sk1] do
+    Sk1[j] := Sk1[j]*2*I*Im(centers[j]);
+  end for;
+  Sk1int := [Integral(f) : f in Sk1];
+  UU := UpperHalfPlane();
+  locc := func< z, j | ComplexValue(PlaneToDisc(DDs[j], DiscToPlane(UU, z))) >;
+  Delta := ContainingTriangleGroup(Gamma);
+  DD := UnitDisc(Gamma : Precision := prec);
+  VD := FundamentalDomain(Delta, DD);
+  rho := Max([Abs(z) : z in VD]);
+  eps := (RealField(CC)!10)^(-(prec div 2));
+  alphas := CosetRepresentatives(Gamma);
+  whichcoset := Gamma`TriangleWhichCoset;
+  v := VD[vi];
+  // initial segment: base point w_a = 0 to v inside the identity coset's chart
+  idind := Index(alphas, Delta!1);
+  error if idind eq 0, "identity is not among the coset representatives";
+  j0 := whichcoset[idind];
+  l0 := locc(DD!0, j0);
+  l1 := locc(v, j0);
+  assert Abs(l0) lt rho + eps and Abs(l1) lt rho + eps;
+  total := Evaluate(Sk1int[j0], l1) - Evaluate(Sk1int[j0], l0);
+  // walk the word of alphas[ind], carrying the vertex along
+  alpha0 := Delta!1;
+  p0 := v;
+  for s in Eltseq(alphas[ind]) do
+    alpha1 := alpha0*Delta.s;
+    indx := Index(alphas, alpha1);
+    error if indx eq 0,
+      "coset representatives are not prefix-closed: partial word is not a representative";
+    j := whichcoset[indx];
+    p1 := alpha1*v;
+    l0 := locc(p0, j);
+    l1 := locc(p1, j);
+    assert Abs(l0) lt rho + eps and Abs(l1) lt rho + eps;
+    total +:= Evaluate(Sk1int[j], l1) - Evaluate(Sk1int[j], l0);
+    p0 := p1;
+    alpha0 := alpha1;
+  end for;
+  return total;
 end intrinsic;
 
 /*

--- a/Code/genusone.m
+++ b/Code/genusone.m
@@ -258,6 +258,63 @@ intrinsic TriangleMakeLattice(Lambda::SeqEnum[FldComElt]) -> Any
   return L;
 end intrinsic;
 
+intrinsic TriangleAJSegment(aCC::FldComElt, bCC::FldComElt, Gamma::GrpPSL2Tri, Sk1int::SeqEnum, DD::SpcHyd) -> FldComElt
+  {Integrate the Gamma-invariant differential (chart antiderivatives Sk1int)
+   along the straight segment from aCC to bCC (disc coordinates).  Each piece
+   is transported into the fundamental domain by the element reducing its
+   midpoint -- which leaves the integral of an invariant form unchanged --
+   and evaluated in the chart minimizing its local coordinates; the segment
+   is adaptively subdivided only if no chart covers a piece.  For a short
+   segment through known geometry this is a single piece, a single chart.}
+
+  CC := Parent(aCC);
+  DDs := Gamma`TriangleDDs;
+  Delta := ContainingTriangleGroup(Gamma);
+  rho := Max([Abs(z) : z in FundamentalDomain(Delta, DD)]);
+  prec := Precision(CC);
+  eps := (RealField(CC)!10)^(-(prec div 2));
+  UU := UpperHalfPlane();
+  nv := #Sk1int;
+  locc := function(z, j)  // local coordinate (a complex number) of the UHP point z in chart j
+    return ComplexValue(PlaneToDisc(DDs[j], z));
+  end function;
+  k := 1;
+  repeat
+    ok := true;
+    total := CC!0;
+    for l in [0..k-1] do
+      p := aCC + (bCC-aCC)*l/k;
+      q := aCC + (bCC-aCC)*(l+1)/k;
+      mred, delta := FDReduce(DD!((p+q)/2), Gamma);
+      // convention check: delta must be the element carrying the input to
+      // the reduced point (fires loudly if FDReduce's return order or
+      // action direction ever changes)
+      assert Abs(ComplexValue(delta*(DD!((p+q)/2))) - ComplexValue(mred)) lt 10^(-10);
+      pr := DiscToPlane(UU, delta*(DD!p));
+      qr := DiscToPlane(UU, delta*(DD!q));
+      jj := 1;
+      best := Max(Abs(locc(pr, 1)), Abs(locc(qr, 1)));
+      for j in [2..nv] do
+        r := Max(Abs(locc(pr, j)), Abs(locc(qr, j)));
+        if r lt best then
+          best := r; jj := j;
+        end if;
+      end for;
+      if best ge rho + eps then  // piece too coarse: subdivide further
+        ok := false;
+        break;
+      end if;
+      total +:= Evaluate(Sk1int[jj], locc(qr, jj)) - Evaluate(Sk1int[jj], locc(pr, jj));
+    end for;
+    if not ok then
+      k *:= 2;
+      error if k gt 1024,
+        "integration path cannot be covered by the expansion charts even after 1024 subdivisions";
+    end if;
+  until ok;
+  return total;
+end intrinsic;
+
 intrinsic TriangleDiscToComplexPlane(w::SpcHydElt, Gamma::GrpPSL2Tri, Sk::SeqEnum) -> Any
   {Given an element w of the hyperbolic disc, outputs the corresponding point in the complex plane (mod the lattice Lambda).}
 
@@ -287,56 +344,7 @@ intrinsic TriangleDiscToComplexPlane(w::SpcHydElt, Gamma::GrpPSL2Tri, Sk::SeqEnu
   // This is the same chart-by-chart pattern the period computation below has
   // always used, and unlike chaining charts through single overlap
   // midpoints, it makes no assumption about how the charts are laid out.
-  Delta := ContainingTriangleGroup(Gamma);
-  rho := Max([Abs(z) : z in FundamentalDomain(Delta, DD)]);
-  eps := (RealField(CC)!10)^(-prec/2);
-  UU := UpperHalfPlane();
-  nv := #Sk1;
-  locc := function(z, j)  // local coordinate (a complex number) of the UHP point z in chart j
-    return ComplexValue(PlaneToDisc(DDs[j], z));
-  end function;
-  segint := function(aCC, bCC)  // integral of f dz from aCC to bCC (disc coordinates)
-    k := 1;
-    repeat
-      ok := true;
-      total := CC!0;
-      for l in [0..k-1] do
-        p := aCC + (bCC-aCC)*l/k;
-        q := aCC + (bCC-aCC)*(l+1)/k;
-        // transport this piece into the fundamental domain by the element
-        // reducing its midpoint; both endpoints ride along, so the piece
-        // stays contiguous and its integral is unchanged (f dz is invariant)
-        mred, delta := FDReduce(DD!((p+q)/2), Gamma);
-        // convention check: delta must be the element carrying the input to
-        // the reduced point (fires loudly if FDReduce's return order or
-        // action direction ever changes)
-        assert Abs(ComplexValue(delta*(DD!((p+q)/2))) - ComplexValue(mred)) lt 10^(-10);
-        pr := DiscToPlane(UU, delta*(DD!p));
-        qr := DiscToPlane(UU, delta*(DD!q));
-        // best chart for this piece
-        jj := 1;
-        best := Max(Abs(locc(pr, 1)), Abs(locc(qr, 1)));
-        for j in [2..nv] do
-          r := Max(Abs(locc(pr, j)), Abs(locc(qr, j)));
-          if r lt best then
-            best := r; jj := j;
-          end if;
-        end for;
-        if best ge rho + eps then  // piece too coarse: subdivide further
-          ok := false;
-          break;
-        end if;
-        total +:= Evaluate(Sk1int[jj], locc(qr, jj)) - Evaluate(Sk1int[jj], locc(pr, jj));
-      end for;
-      if not ok then
-        k *:= 2;
-        error if k gt 1024,
-          "integration path cannot be covered by the expansion charts even after 1024 subdivisions";
-      end if;
-    until ok;
-    return total;
-  end function;
-  w_CC := segint(CC!0, ComplexValue(w));
+  w_CC := TriangleAJSegment(CC!0, ComplexValue(w), Gamma, Sk1int, DD);
   return w_CC;
 end intrinsic;
 
@@ -411,10 +419,11 @@ intrinsic TriangleCosetVertexToComplexPlane(ind::RngIntElt, vi::RngIntElt, Gamma
    integrating chart by chart along the coset-graph path from the identity
    to alphas[ind], as in the period computation: the coset labels produced
    by the enumeration (KMSV Algorithms 3.5/3.8) are prefix-closed, so every
-   partial word of alphas[ind] is itself a coset representative, consecutive
-   translates of the fundamental triangle are adjacent, and each step
-   integrates between alpha0*v and alpha1*v inside the chart of the new
-   coset.  The base point is w_a = 0 (the disc is centered at z_a).}
+   partial word of alphas[ind] is itself a coset representative and
+   consecutive translates of the fundamental triangle are adjacent tiles;
+   each step integrates between alpha0*v and alpha1*v via TriangleAJSegment,
+   which selects the covering chart per segment.  The base point is
+   w_a = 0 (the disc is centered at z_a).}
 
   assert Genus(Gamma) eq 1;
   prec := Precision(BaseRing(Parent(Sk[1][1])));
@@ -426,38 +435,29 @@ intrinsic TriangleCosetVertexToComplexPlane(ind::RngIntElt, vi::RngIntElt, Gamma
     Sk1[j] := Sk1[j]*2*I*Im(centers[j]);
   end for;
   Sk1int := [Integral(f) : f in Sk1];
-  UU := UpperHalfPlane();
-  locc := func< z, j | ComplexValue(PlaneToDisc(DDs[j], DiscToPlane(UU, z))) >;
   Delta := ContainingTriangleGroup(Gamma);
   DD := UnitDisc(Gamma : Precision := prec);
   VD := FundamentalDomain(Delta, DD);
-  rho := Max([Abs(z) : z in VD]);
-  eps := (RealField(CC)!10)^(-(prec div 2));
   alphas := CosetRepresentatives(Gamma);
-  whichcoset := Gamma`TriangleWhichCoset;
   v := VD[vi];
-  // initial segment: base point w_a = 0 to v inside the identity coset's chart
-  idind := Index(alphas, Delta!1);
-  error if idind eq 0, "identity is not among the coset representatives";
-  j0 := whichcoset[idind];
-  l0 := locc(DD!0, j0);
-  l1 := locc(v, j0);
-  assert Abs(l0) lt rho + eps and Abs(l1) lt rho + eps;
-  total := Evaluate(Sk1int[j0], l1) - Evaluate(Sk1int[j0], l0);
-  // walk the word of alphas[ind], carrying the vertex along
+  // Waypoints from the coset word: each partial word of alphas[ind] is a
+  // coset representative (the enumeration's labels are prefix-closed) and
+  // consecutive translates of the fundamental triangle are adjacent tiles,
+  // so the segments below are short hops through known geometry.  Each hop
+  // is integrated by TriangleAJSegment, which picks the chart minimizing
+  // the local coordinates of the endpoints; the expansion charts exist only
+  // at one representative vertex per cycle (Federalize), so a fixed
+  // per-coset chart assignment is NOT guaranteed to cover both endpoints --
+  // the covering chart must be chosen per segment, with subdivision as a
+  // fallback for awkward layouts.  The base point is w_a = 0 (the disc is
+  // centered at z_a).
+  total := TriangleAJSegment(CC!0, ComplexValue(v), Gamma, Sk1int, DD);
   alpha0 := Delta!1;
   p0 := v;
   for s in Eltseq(alphas[ind]) do
     alpha1 := alpha0*Delta.s;
-    indx := Index(alphas, alpha1);
-    error if indx eq 0,
-      "coset representatives are not prefix-closed: partial word is not a representative";
-    j := whichcoset[indx];
     p1 := alpha1*v;
-    l0 := locc(p0, j);
-    l1 := locc(p1, j);
-    assert Abs(l0) lt rho + eps and Abs(l1) lt rho + eps;
-    total +:= Evaluate(Sk1int[j], l1) - Evaluate(Sk1int[j], l0);
+    total +:= TriangleAJSegment(ComplexValue(p0), ComplexValue(p1), Gamma, Sk1int, DD);
     p0 := p1;
     alpha0 := alpha1;
   end for;

--- a/Code/newton.m
+++ b/Code/newton.m
@@ -189,29 +189,41 @@ intrinsic NewtonGetRamificationPoints(Gamma::GrpPSL2Tri) -> GrpPSL2Tri
   sigma_cycs := [CycleDecomposition(s) : s in sigma_switch];
   pts := [];
   mults := [];
+  inds := [];
   for i := 1 to 3 do
     cycs := sigma_cycs[i];
     pts_i := [];
     mults_i := [];
+    inds_i := [];
     for cyc in cycs do
       Append(~mults_i, #cyc);
       ind := cyc[1];
-      Append(~pts_i, FD[4*(ind-1)+i]);
+      Append(~inds_i, ind);
+      Append(~pts_i, FD[4*(ind-1)+i]);  // = alphas[ind]*V[i], V the Delta-FD
     end for;
     Append(~pts, pts_i);
     Append(~mults, mults_i);
+    Append(~inds, inds_i);
   end for;
   pts := [pts[1], pts[3], pts[2]]; // now switch back to white, black, cross
   mults := [mults[1], mults[3], mults[2]];
+  inds := [inds[1], inds[3], inds[2]];
+  slots := [1, 3, 2]; // Delta-FD vertex slot for white, black, cross resp.
   // delete the point that maps to point at infinity
   Remove(~pts[1],1);
   Remove(~mults[1],1);
-  // map points in disc to points on elliptic curve
+  Remove(~inds[1],1);
+  // map points to the elliptic curve.  Each point is alphas[ind]*V[slot], so
+  // its Abel-Jacobi value is computed exactly by walking the coset-graph
+  // path from the identity to alphas[ind] chart by chart (the same
+  // structure the period computation uses) -- no reduction and no
+  // nearest-chart search needed
   pts_E := [];
   for i := 1 to 3 do
     pts_E_i := [];
     for j := 1 to #pts[i] do
-      Append(~pts_E_i, TriangleDiscToEllipticCurve(pts[i][j], Gamma, Sk, x, y));
+      w_CC := TriangleCosetVertexToComplexPlane(inds[i][j], slots[i], Gamma, Sk);
+      Append(~pts_E_i, TriangleAJToEllipticCurve(w_CC, Gamma, x, y));
     end for;
     Append(~pts_E, pts_E_i);
   end for;

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -30,7 +30,15 @@ The runner executes, in order:
    through the x-line, so the 0-fiber is 4*O + 2*(2-torsion) and sums to O:
    no extra zero despite s < d, `NeedsExtra` false — which shows the
    predicate must be data-driven, not combinatorial.
-5. **`test_powser_consistency.m`** (slow, `RUNSLOW=1`): degree-7 example;
+5. **`test_genusone_aj.m`**: unit tests for the genus-1 Abel-Jacobi
+   evaluation.  On two examples (4T5-4_4_3.1-a, and a (5,5,4) triple whose
+   chart layout is kept as a regression), checks that the exact coset-path
+   evaluation (`TriangleCosetVertexToComplexPlane`) and the adaptive path
+   integrator (`TriangleDiscToComplexPlane`) agree modulo the period
+   lattice at every fundamental domain vertex, and that all ramification
+   points satisfy the curve equation to working accuracy (the original
+   single-expansion evaluation left only ~5 correct digits).
+6. **`test_powser_consistency.m`** (slow, `RUNSLOW=1`): degree-7 example;
    computes the weight-4 power series basis with both `Al := "Arnoldi"` and
    `Al := "CArnoldi"` at 100 digits and asserts the echelonized bases agree
    as functions to 1e-70, that both minimal singular values are below

--- a/Tests/run_tests.sh
+++ b/Tests/run_tests.sh
@@ -7,8 +7,13 @@ FAILED=0
 
 # ---- 1. C solver selftest -------------------------------------------------
 BIN=${POWSER_ARNOLDI_BIN:-Cext/powser_arnoldi}
-if [ ! -x "$BIN" ] && command -v make >/dev/null 2>&1; then
-    (cd Cext && make powser_arnoldi >/dev/null 2>&1 || make mac >/dev/null 2>&1)
+# always invoke make (not only when the binary is missing): make no-ops when
+# the binary is up to date, and a stale binary from an older checkout
+# silently reintroduces already-fixed bugs (observed: a pre-p-notation
+# binary truncating all solver output to 30 digits).  An explicitly set
+# POWSER_ARNOLDI_BIN is respected and never rebuilt.
+if [ -z "${POWSER_ARNOLDI_BIN:-}" ] && command -v make >/dev/null 2>&1; then
+    (cd Cext && { make powser_arnoldi >/dev/null 2>&1 || make mac >/dev/null 2>&1; })
 fi
 # export an absolute path so the Magma tests (which read POWSER_ARNOLDI_BIN
 # via GetEnv) actually use the binary we just built, instead of silently

--- a/Tests/run_tests.sh
+++ b/Tests/run_tests.sh
@@ -54,6 +54,7 @@ run_magma_test() {
 run_magma_test Tests/test_basic_belyi.m
 run_magma_test Tests/test_carnoldi_belyi.m
 run_magma_test Tests/test_genusone_extra_zero.m
+run_magma_test Tests/test_genusone_aj.m
 if [ -n "$RUNSLOW" ]; then
     run_magma_test Tests/test_powser_consistency.m
 else

--- a/Tests/test_genusone_aj.m
+++ b/Tests/test_genusone_aj.m
@@ -1,0 +1,88 @@
+// Unit tests for the genus-1 Abel-Jacobi evaluation machinery:
+//
+//   * TriangleCosetVertexToComplexPlane -- the exact coset-path evaluation
+//     (walks the word of the coset representative chart by chart, as the
+//     period computation does; KMSV section 3);
+//   * TriangleDiscToComplexPlane -- the adaptive path integrator for
+//     anonymous disc points;
+//   * NewtonGetRamificationPoints -- the ramification points on the curve.
+//
+// Checks, on each example:
+//   (1) the two evaluations agree modulo the period lattice at every
+//       fundamental domain vertex (they share only the series data, so this
+//       cross-validates both implementations and the periods);
+//   (2) every ramification point returned satisfies the curve equation to
+//       working accuracy (the original single-expansion evaluation left only
+//       ~5 correct digits and fails this by many orders of magnitude).
+//
+// The second example, with signature (5,5,4), is the chart layout that broke
+// the earlier midpoint-chaining implementation; it is kept as a regression.
+AttachSpec("Code/spec");
+
+prec := 40;
+
+function CheckExample(sigma)
+  Gamma := TriangleSubgroup(sigma);
+  Gamma := NewtonGetNumericalData(Gamma : prec := prec);
+  Gamma := NewtonGetRamificationPoints(Gamma);
+  Sk := Gamma`TriangleNewtonSk;
+  FD := Gamma`TriangleNewtonFD;
+  CC := BaseRing(Parent(Sk[1][1]));
+  RR := RealField(CC);
+  d := Gamma`TriangleD;
+
+  // lattice data for comparisons mod Lambda
+  Lambda := Gamma`TrianglePeriodLattice;
+  M := Matrix([[Re(l), Im(l)] : l in Lambda]);
+  latres := function(z)  // distance from z to the nearest lattice point
+    sol := Solution(M, Vector([Re(z), Im(z)]));
+    return Abs(z - Round(sol[1])*Lambda[1] - Round(sol[2])*Lambda[2]);
+  end function;
+
+  // (1) coset-path vs adaptive evaluation, at every FD vertex of every coset
+  eps_agree := RR!10^(-(3*prec) div 4);
+  maxdisagree := RR!0;
+  for ind := 1 to d do
+    for slot := 1 to 3 do
+      w1 := TriangleCosetVertexToComplexPlane(ind, slot, Gamma, Sk);
+      w2 := TriangleDiscToComplexPlane(FD[4*(ind-1)+slot], Gamma, Sk);
+      dis := latres(w1 - w2);
+      if dis gt maxdisagree then maxdisagree := dis; end if;
+    end for;
+  end for;
+  printf "max disagreement (mod Lambda) between coset-path and adaptive AJ: %o\n",
+    RealField(6)!maxdisagree;
+  assert maxdisagree lt eps_agree;
+
+  // (2) ramification points satisfy the curve equation
+  c4, c6 := Explode(Gamma`TriangleNumericalCurveCoefficients);
+  eps_curve := RR!10^(-(prec div 2));
+  maxres := RR!0;
+  for pts in [Gamma`TriangleNewtonRamificationPoints0,
+              Gamma`TriangleNewtonRamificationPoints1,
+              Gamma`TriangleNewtonRamificationPointsoo] do
+    for P in pts do
+      f := P[1]^3 - 27*c4*P[1] - 54*c6;
+      scale := Max(RR!1, Max(Abs(P[2])^2, Abs(f)));
+      res := Abs(P[2]^2 - f)/scale;
+      if res gt maxres then maxres := res; end if;
+    end for;
+  end for;
+  printf "max relative curve residual of ramification points: %o\n",
+    RealField(6)!maxres;
+  assert maxres lt eps_curve;
+
+  return true;
+end function;
+
+// LMFDB 4T5-4_4_3.1-a: degree 4, genus 1, hyperbolic (4,4,3)
+S4 := Sym(4);
+assert CheckExample([S4 | S4![2,3,4,1], S4![3,1,4,2], S4![3,2,4,1]]);
+
+// signature (5,5,4), degree 6, genus 1: the chart layout that defeated the
+// midpoint-chaining implementation (regression)
+S6 := Sym(6);
+assert CheckExample([S6 | (1,2,3,5,6), (1,4,2,6,3), (1,2,3,4)(5,6)]);
+
+print "ALL TESTS PASSED";
+quit;

--- a/Tests/test_genusone_extra_zero.m
+++ b/Tests/test_genusone_extra_zero.m
@@ -64,7 +64,7 @@ assert Gamma2`TriangleNewtonNeedsExtra;
 // would wrongly add the special point here (3 extra equations but only
 // 2 extra variables: overdetermined system).
 // (https://www.lmfdb.org/Belyi/6T7/4.2/4.2/3.3/a/)
-sigma3 := [S6 | S6b![5,1,6,2,4,3], S6b![3,5,4,6,2,1], S6b![5,3,4,2,6,1]];
+sigma3 := [S6 | S6![5,1,6,2,4,3], S6![3,5,4,6,2,1], S6![5,3,4,2,6,1]];
 Gamma3 := TriangleSubgroup(sigma3);
 X3, phi3 := BelyiMap(Gamma3 : prec := 40);
 assert BelyiMapSanityCheck(sigma3, X3, phi3);
@@ -74,7 +74,7 @@ assert assigned Gamma3`TriangleNewtonNeedsExtra;
 assert not Gamma3`TriangleNewtonNeedsExtra;
 
 // ---- Extra zero present: sigma_0 not a d-cycle ----------------------------
-// LMFDB 6T15-5.1_5.1_4.2-b: degree 6, genus 1, hyperbolic (orders (5,5,3)),
+// LMFDB 6T15-5.1_5.1_4.2-b: degree 6, genus 1, hyperbolic (orders (5,5,4)),
 // defined over quartic field with label 4.2.24000.2
 // sigma_0 has cycle type 5.1, so s = 5, t = 2, and the 0-fiber is
 // 5*O + Q with Q ne O.  The special point's class is

--- a/Tests/test_genusone_extra_zero.m
+++ b/Tests/test_genusone_extra_zero.m
@@ -64,8 +64,7 @@ assert Gamma2`TriangleNewtonNeedsExtra;
 // would wrongly add the special point here (3 extra equations but only
 // 2 extra variables: overdetermined system).
 // (https://www.lmfdb.org/Belyi/6T7/4.2/4.2/3.3/a/)
-S6b := Sym(6);
-sigma3 := [S6b | S6b![5,1,6,2,4,3], S6b![3,5,4,6,2,1], S6b![5,3,4,2,6,1]];
+sigma3 := [S6 | S6b![5,1,6,2,4,3], S6b![3,5,4,6,2,1], S6b![5,3,4,2,6,1]];
 Gamma3 := TriangleSubgroup(sigma3);
 X3, phi3 := BelyiMap(Gamma3 : prec := 40);
 assert BelyiMapSanityCheck(sigma3, X3, phi3);
@@ -73,6 +72,25 @@ assert Genus(X3) eq 1;
 assert Degree(BaseRing(X3)) eq 1;   // defined over Q
 assert assigned Gamma3`TriangleNewtonNeedsExtra;
 assert not Gamma3`TriangleNewtonNeedsExtra;
+
+// ---- Extra zero present: sigma_0 not a d-cycle ----------------------------
+// LMFDB 6T15-5.1_5.1_4.2-b: degree 6, genus 1, hyperbolic (orders (5,5,3)),
+// defined over quartic field with label 4.2.24000.2
+// sigma_0 has cycle type 5.1, so s = 5, t = 2, and the 0-fiber is
+// 5*O + Q with Q ne O.  The special point's class is
+//   P_s ~ (s+t)*O - D_0, i.e. P_s = -(sum of the 0-fiber) = -Q ne O
+// in the group law, so the extra zero is PROVABLY present for this triple
+// (the degenerate case P_s = O cannot occur) and the Newton system needs
+// the special point to be square.
+// (https://www.lmfdb.org/Belyi/6T15/5.1/5.1/4.2/b/)
+sigma4 := [S6 | (1,2,3,5,6), (1,4,2,6,3), (1,2,3,4)(5,6)];
+Gamma4 := TriangleSubgroup(sigma4);
+X4, phi4 := BelyiMap(Gamma4 : prec := 40);
+assert BelyiMapSanityCheck(sigma4, X4, phi4);
+assert Genus(X4) eq 1;
+assert Degree(BaseRing(X4)) eq 4;
+assert assigned Gamma4`TriangleNewtonNeedsExtra;
+assert Gamma4`TriangleNewtonNeedsExtra;
 
 print "ALL TESTS PASSED";
 quit;


### PR DESCRIPTION
Fixing a bug in the genus 1 code in the case where the numerator and denominator have a common zero. Abel–Jacobi evaluation of ramification points now integrates along coset-graph paths (`TriangleCosetVertexToComplexPlane` + adaptive `TriangleAJSegment`), choosing expansion charts by local-coordinate minimization rather than a fixed per-coset assignment or midpoint chart-chaining. This bug was discovered in #38, and I added the example that was breaking from that PR (https://www.lmfdb.org/Belyi/6T15/5.1/5.1/4.2/b/) as a test.